### PR TITLE
ESlint ignore node_modules

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,2 @@
 dist/**/*
+node_modules


### PR DESCRIPTION
To prevent `lint:fix` script failing.