### PR TITLE
Fix suspense hanging

### DIFF
--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -116,7 +116,9 @@ function useSWR<Data = any, Error = any>(
   }
 
   // stale: get from cache
-  let [data, setData] = useState(useHydration() ? undefined : cacheGet(key))
+  let [data, setData] = useState(
+    config.suspense ? cacheGet(key) : useHydration() ? undefined : cacheGet(key)
+  )
   let [error, setError] = useState()
   let [isValidating, setIsValidating] = useState(false)
 
@@ -335,7 +337,7 @@ function useSWR<Data = any, Error = any>(
   }, [key, config.refreshInterval, revalidate])
 
   // suspense (client side only)
-  if (config.suspense && !data) {
+  if (config.suspense && typeof data === 'undefined') {
     if (typeof window !== 'undefined') {
       if (!CONCURRENT_PROMISES[key]) {
         // need to trigger revalidate immediately

--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -119,6 +119,8 @@ function useSWR<Data = any, Error = any>(
   let [data, setData] = useState(
     config.suspense ? cacheGet(key) : useHydration() ? undefined : cacheGet(key)
   )
+  // it is fine to call `useHydration` conditionally here
+  // because `config.suspense` should never change
   let [error, setError] = useState()
   let [isValidating, setIsValidating] = useState(false)
 


### PR DESCRIPTION
The problem is caused by `useHydration`. 

When enabling SSR with frameworks like Next.js, we have to match the SSRed result with the client rendered result on hydration, so we skipped from reading the cache.  
But when suspense is enabled, we need to read from cache before the component is mounted.

Close #46 #39 
