### PR TITLE
Improve export for IntelliSense

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 export * from './use-swr'
-export { default } from './use-swr'
+export { default as useSWR } from './use-swr'
 export { useSWRPages } from './use-swr-pages'
 export {
   ConfigInterface,
@@ -8,3 +8,4 @@ export {
   keyInterface,
   responseInterface
 } from './types'
+export default useSWR

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 export * from './use-swr'
-export { default as useSWR } from './use-swr'
+import { default as useSWR } from './use-swr'
 export { useSWRPages } from './use-swr-pages'
 export {
   ConfigInterface,


### PR DESCRIPTION
This is an odd change, but without this, the IntelliSense doesn't know that `useSWR` is the export from this package (it tries to import from `swr/dist/use-swr` instead),

Functionally, this only adds a new export to the package: `useSWR`