### PR TITLE
Fix error broadcasting

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,12 +22,11 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "lint-staged"
+      "pre-commit": "npm run types:check && lint-staged"
     }
   },
   "lint-staged": {
     "*.{ts,tsx}": [
-      "npm run types:check",
       "npm run lint:fix",
       "npm run format",
       "git add"

--- a/src/types.ts
+++ b/src/types.ts
@@ -38,14 +38,21 @@ export interface RevalidateOptionInterface {
 
 type keyFunction = () => string
 export type keyInterface = string | keyFunction
-export type updaterInterface = (
-  shouldRevalidate?: boolean
+export type updaterInterface<Data = any, Error = any> = (
+  shouldRevalidate?: boolean,
+  data?: Data,
+  error?: Error
 ) => boolean | Promise<boolean>
 export type triggerInterface = (key: string, shouldRevalidate?: boolean) => void
-export type mutateInterface = (
+export type mutateInterface<Data = any> = (
   key: string,
-  data: any,
+  data: Data,
   shouldRevalidate?: boolean
+) => void
+export type broadcastStateInterface<Data = any, Error = any> = (
+  key: string,
+  data: Data,
+  error?: Error
 ) => void
 export type responseInterface<Data, Error> = {
   data?: Data


### PR DESCRIPTION
cc @pacocoursey as we discussed somewhere else:

Currently if there're multiple SWR hooks sharing the same key, and one of them revalidates, it will broadcast the updated state to others (so we can deduplicate concurrent requests). But it only broadcasts data updates, not errors. This PR fixes the bug.

Also, some tiny performance improvements are made (using `unstable_batchedUpdates` and reducing the number of cache reads), and related tests are added.
