### PR TITLE
Add One-Click Deploy button to examples

### DIFF
--- a/examples/api-hooks/README.md
+++ b/examples/api-hooks/README.md
@@ -1,5 +1,11 @@
 # API Hooks
 
+## One-Click Deploy
+
+Deploy your own SWR project with ZEIT Now.
+
+[![Deploy with ZEIT Now](https://zeit.co/button)](https://zeit.co/new/project?template=https://github.com/zeit/swr/tree/master/examples/focus-revalidate)
+
 ## How to Use
 
 Download the example:

--- a/examples/basic-typescript/README.md
+++ b/examples/basic-typescript/README.md
@@ -1,5 +1,11 @@
 # Basic TypeScript
 
+## One-Click Deploy
+
+Deploy your own SWR project with ZEIT Now.
+
+[![Deploy with ZEIT Now](https://zeit.co/button)](https://zeit.co/new/project?template=https://github.com/zeit/swr/tree/master/examples/basic-typescript)
+
 ## How to Use
 
 Download the example:

--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -1,5 +1,11 @@
 # Basic
 
+## One-Click Deploy
+
+Deploy your own SWR project with ZEIT Now.
+
+[![Deploy with ZEIT Now](https://zeit.co/button)](https://zeit.co/new/project?template=https://github.com/zeit/swr/tree/master/examples/basic)
+
 ## How to Use
 
 Download the example:

--- a/examples/focus-revalidate/README.md
+++ b/examples/focus-revalidate/README.md
@@ -1,5 +1,11 @@
 # Focus Revalidate
 
+## One-Click Deploy
+
+Deploy your own SWR project with ZEIT Now.
+
+[![Deploy with ZEIT Now](https://zeit.co/button)](https://zeit.co/new/project?template=https://github.com/zeit/swr/tree/master/examples/focus-revalidate)
+
 ## How to Use
 
 Download the example:

--- a/examples/global-fetcher/README.md
+++ b/examples/global-fetcher/README.md
@@ -1,5 +1,11 @@
 # Global Fetcher
 
+## One-Click Deploy
+
+Deploy your own SWR project with ZEIT Now.
+
+[![Deploy with ZEIT Now](https://zeit.co/button)](https://zeit.co/new/project?template=https://github.com/zeit/swr/tree/master/examples/global-fetcher)
+
 ## How to Use
 
 Download the example:

--- a/examples/optimistic-ui/README.md
+++ b/examples/optimistic-ui/README.md
@@ -1,5 +1,11 @@
 # Optimistic UI
 
+## One-Click Deploy
+
+Deploy your own SWR project with ZEIT Now.
+
+[![Deploy with ZEIT Now](https://zeit.co/button)](https://zeit.co/new/project?template=https://github.com/zeit/swr/tree/master/examples/optimistic-ui)
+
 ## How to Use
 
 Download the example:

--- a/examples/pagination/README.md
+++ b/examples/pagination/README.md
@@ -1,5 +1,11 @@
 # Pagination
 
+## One-Click Deploy
+
+Deploy your own SWR project with ZEIT Now.
+
+[![Deploy with ZEIT Now](https://zeit.co/button)](https://zeit.co/new/project?template=https://github.com/zeit/swr/tree/master/examples/pagination)
+
 ## How to Use
 
 Download the example:

--- a/examples/refetch-interval/README.md
+++ b/examples/refetch-interval/README.md
@@ -1,5 +1,11 @@
 # Refetch Interval
 
+## One-Click Deploy
+
+Deploy your own SWR project with ZEIT Now.
+
+[![Deploy with ZEIT Now](https://zeit.co/button)](https://zeit.co/new/project?template=https://github.com/zeit/swr/tree/master/examples/refetch-interval)
+
 ## How to Use
 
 Download the example:

--- a/examples/storage-tab-sync/README.md
+++ b/examples/storage-tab-sync/README.md
@@ -1,5 +1,11 @@
 # Storage Tab Sync
 
+## One-Click Deploy
+
+Deploy your own SWR project with ZEIT Now.
+
+[![Deploy with ZEIT Now](https://zeit.co/button)](https://zeit.co/new/project?template=https://github.com/zeit/swr/tree/master/examples/storage-tab-sync)
+
 ## How to Use
 
 Download the example:


### PR DESCRIPTION
I think ZEIT team should maintain deployed versions or the CodeSandboxes of each example too.