### PR TITLE
replace useLayoutEffect by useIsomorphicLayoutEffect to avoid ssr warnings

### DIFF
--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -1,5 +1,6 @@
 import {
   useState,
+  useEffect,
   useLayoutEffect,
   useRef,
   useContext,
@@ -286,8 +287,13 @@ function useSWR<Data = any, Error = any>(
     [key]
   )
 
-  // mounted
-  useLayoutEffect(() => {
+  // React currently throws a warning when using useLayoutEffect on the server.
+  // To get around it, we can conditionally useEffect on the server (no-op) and
+  // useLayoutEffect in the browser.
+  const useIsomorphicLayoutEffect = IS_SERVER ? useEffect : useLayoutEffect
+
+  // mounted (client side rendering)
+  useIsomorphicLayoutEffect(() => {
     if (!key) return undefined
 
     // after `key` updates, we need to mark it as mounted


### PR DESCRIPTION
closes #54 

This is the same "fix" used by the react-redux team - seen in https://github.com/reduxjs/react-redux/blob/2eac86163be2bd5627dab3e33e8b4e0926895442/src/hooks/useSelector.js#L22