### PR TITLE
Cache collection

### DIFF
--- a/src/cache.ts
+++ b/src/cache.ts
@@ -1,0 +1,16 @@
+// Cache
+const __cache = new Map()
+
+function cacheGet(key: string): any {
+  return __cache.get(key)
+}
+
+function cacheSet(key: string, value: any) {
+  return __cache.set(key, value)
+}
+
+function cacheClear() {
+  __cache.clear()
+}
+
+export { cacheGet, cacheSet, cacheClear }

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -1,16 +1,80 @@
-// Cache
-const __cache = new Map()
+const cache = new Map()
+const requestIdleCallback =
+  window['requestIdleCallback'] || ((fn, ...args) => setTimeout(fn, 1, ...args))
 
 function cacheGet(key: string): any {
-  return __cache.get(key)
+  return cache.get(key)
 }
-
 function cacheSet(key: string, value: any) {
-  return __cache.set(key, value)
+  cache.set(key, value)
+}
+function cacheDelete(key: string) {
+  cache.delete(key)
 }
 
+// LRU cache collection implementation
+// ===================================
+const keyCnt = new Map()
+
+let inactiveKeys = new Set()
+let inactiveKeysToBeDeleted = new Set()
+
+// we only store 300~600 inactive keys
+const MAX_SIZE = 300
+function activate(key) {
+  if (inactiveKeys.has(key)) {
+    inactiveKeys.delete(key)
+    return
+  }
+  if (inactiveKeysToBeDeleted.has(key)) {
+    inactiveKeysToBeDeleted.delete(key)
+  }
+}
+function inactivate(key) {
+  inactiveKeys.add(key)
+  if (inactiveKeys.size >= MAX_SIZE) {
+    // collect everything inside `inactiveKeysToBeDeleted`
+    inactiveKeysToBeDeleted.forEach(cacheDelete)
+
+    inactiveKeysToBeDeleted = inactiveKeys
+    inactiveKeys = new Set()
+  }
+}
+
+// when a hook mounts
+function hookActive(...keys: string[]) {
+  // don't block rendering, etc.
+  requestIdleCallback(_keys => {
+    for (let i = 0; i < _keys.length; ++i) {
+      const key = _keys[i]
+      keyCnt[key] = (keyCnt[key] || 0) + 1
+      if (keyCnt[key] === 1) {
+        activate(key)
+      }
+    }
+  }, keys)
+}
+
+// when a hook unmounts
+function hookInactive(...keys: string[]) {
+  requestIdleCallback(_keys => {
+    for (let i = 0; i < _keys.length; ++i) {
+      const key = _keys[i]
+      keyCnt[key] = keyCnt[key] - 1
+      if (keyCnt[key] === 0) {
+        inactivate(key)
+      }
+    }
+  }, keys)
+}
+// ===================================
+
+// reset
 function cacheClear() {
-  __cache.clear()
+  cache.clear()
+  keyCnt.clear()
+  inactiveKeys.clear()
+  inactiveKeysToBeDeleted.clear()
 }
 
-export { cacheGet, cacheSet, cacheClear }
+export { cacheGet, cacheSet, cacheClear, hookActive, hookInactive }

--- a/src/config.ts
+++ b/src/config.ts
@@ -8,21 +8,6 @@ import {
   RevalidateOptionInterface
 } from './types'
 
-// Cache
-const __cache = new Map()
-
-function cacheGet(key: string): any {
-  return __cache.get(key) || undefined
-}
-
-function cacheSet(key: string, value: any) {
-  return __cache.set(key, value)
-}
-
-function cacheClear() {
-  __cache.clear()
-}
-
 // state managers
 const CONCURRENT_PROMISES = {}
 const CONCURRENT_PROMISES_TS = {}
@@ -107,9 +92,6 @@ export {
   CONCURRENT_PROMISES_TS,
   FOCUS_REVALIDATORS,
   CACHE_REVALIDATORS,
-  MUTATION_TS,
-  cacheGet,
-  cacheSet,
-  cacheClear
+  MUTATION_TS
 }
 export default defaultConfig

--- a/src/use-swr-pages.tsx
+++ b/src/use-swr-pages.tsx
@@ -1,6 +1,6 @@
-import React, { useCallback, useMemo, useState, useRef } from 'react'
+import React, { useCallback, useMemo, useState, useRef, useEffect } from 'react'
 
-import { cacheGet, cacheSet } from './cache'
+import { cacheGet, cacheSet, hookActive, hookInactive } from './cache'
 import {
   pagesResponseInterface,
   responseInterface,
@@ -198,6 +198,11 @@ export function useSWRPages<OffsetType, Data, Error>(
     }
     return p
   }, [_pageFn, pageCount, pageSWRs, pageOffsets, pageKey])
+
+  useEffect(() => {
+    hookActive(pageCountKey, pageOffsetKey)
+    return () => hookInactive(pageCountKey, pageOffsetKey)
+  }, [pageKey])
 
   return {
     pages,

--- a/src/use-swr-pages.tsx
+++ b/src/use-swr-pages.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useMemo, useState, useRef } from 'react'
 
-import { cacheGet, cacheSet } from './config'
+import { cacheGet, cacheSet } from './cache'
 import {
   pagesResponseInterface,
   responseInterface,

--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -26,10 +26,11 @@ import defaultConfig, {
   CONCURRENT_PROMISES_TS,
   FOCUS_REVALIDATORS,
   CACHE_REVALIDATORS,
-  MUTATION_TS,
-  cacheGet,
-  cacheSet
+  MUTATION_TS
 } from './config'
+
+import { cacheGet, cacheSet } from './cache'
+
 import SWRConfigContext from './swr-config-context'
 import isDocumentVisible from './libs/is-document-visible'
 import useHydration from './libs/use-hydration'

--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -29,7 +29,7 @@ import defaultConfig, {
   MUTATION_TS
 } from './config'
 
-import { cacheGet, cacheSet } from './cache'
+import { cacheGet, cacheSet, hookActive, hookInactive } from './cache'
 
 import SWRConfigContext from './swr-config-context'
 import isDocumentVisible from './libs/is-document-visible'
@@ -425,6 +425,11 @@ function useSWR<Data = any, Error = any>(
       }
     }
   }, [key, config.refreshInterval, revalidate])
+
+  useEffect(() => {
+    hookActive(key, keyErr)
+    return () => hookInactive(key, keyErr)
+  }, [key])
 
   // suspense
   if (config.suspense) {


### PR DESCRIPTION
This PR adds inactive (LRU based) cache collection implementation.  
By default <=600 inactive keys will be stored.

However, there're a couple of things we need to explore further before landing this feature.

### Performance
For most (~99%) websites, the number of requests per page won't be more than 200. [[1]]
So this feature will add too many unnecessary workload.

A solution can be just skip handling cache collection until its size is near ~3/4 of the maximum allowed cache size.

[1]: https://httparchive.org/reports/state-of-the-web#reqTotal

### API
How does it work with:
- multilayer cache
- namespaced cache

How to customize the cache size?
