### PR TITLE
Improve the pagination API

### DIFF
--- a/examples/pagination/pages/about.js
+++ b/examples/pagination/pages/about.js
@@ -1,5 +1,8 @@
 import Link from 'next/link'
 
 export default () => {
-  return <Link href="/"><a>back</a></Link>
+  return <>
+    <p>When navigating between pages, SWR will recover the pages you've loaded.</p>
+    <Link href="/"><a>back</a></Link>
+  </>
 }

--- a/examples/pagination/pages/page-index.js
+++ b/examples/pagination/pages/page-index.js
@@ -11,7 +11,7 @@ export default () => {
     loadMore
   } = useSWRPages(
     // page key
-    'demo-page',
+    'demo-page-2',
 
     // page component
     ({ offset, withSWR }) => {
@@ -25,16 +25,18 @@ export default () => {
         return <p>loading</p>
       }
 
-      return projects.map(project => 
+      return projects.map(project =>
         <p key={project.id}>{project.name}</p>
       )
     },
 
-    // one page's SWR => offset of next page
-    ({ data: projects }) => {
-      return projects && projects.length
-        ? projects[projects.length - 1].id + 1
-        : null
+    // get next page's offset from the index of current page
+    (SWR, index) => {
+      // there's no next page
+      if (SWR.data && SWR.data.length === 0) return null
+
+      // offset = pageCount × pageSize
+      return (index + 1) * 3
     },
 
     // deps of the page component
@@ -42,13 +44,13 @@ export default () => {
   )
 
   return <div>
-    <h1>Pagination (offset from data)</h1>
+    <h1>Pagination (index as offset)</h1>
     {pages}
     <button onClick={loadMore} disabled={isReachingEnd || isLoadingMore}>
       {isLoadingMore ? '. . .' : isReachingEnd ? 'no more data' : 'load more'}
     </button>
     <hr />
-    <Link href="/page-index"><a>page index based pagination →</a></Link><br/>
+    <Link href="/"><a>data offset based pagination →</a></Link><br />
     <Link href="/about"><a>go to another page →</a></Link>
   </div>
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -77,8 +77,8 @@ export type pageComponentType<Offset, Data, Error> = (
   props: pagesPropsInterface<Offset, Data, Error>
 ) => any
 export type pageOffsetMapperType<Offset, Data, Error> = (
-  data: any,
-  pageSWRs: responseInterface<Data, Error>[]
+  SWR: responseInterface<Data, Error>,
+  index: number
 ) => Offset
 
 export type pagesResponseInterface = {

--- a/src/use-swr-pages.tsx
+++ b/src/use-swr-pages.tsx
@@ -91,7 +91,7 @@ function App () {
 export function useSWRPages<OffsetType, Data, Error>(
   pageKey: string,
   pageFn: pageComponentType<OffsetType, Data, Error>,
-  swrDataToOffset: pageOffsetMapperType<OffsetType, Data, Error>,
+  SWRToOffset: pageOffsetMapperType<OffsetType, Data, Error>,
   deps: any[] = []
 ): pagesResponseInterface {
   const pageCountKey = `_swr_page_count_` + pageKey
@@ -151,22 +151,20 @@ export function useSWRPages<OffsetType, Data, Error>(
         setPageSWRs(swrs => {
           const _swrs = [...swrs]
           _swrs[id] = swr
-
-          if (typeof swr.data !== 'undefined') {
-            // set next page's offset
-            const newPageOffset = swrDataToOffset(swr.data, _swrs)
-            if (pageOffsets[id + 1] !== newPageOffset) {
-              setPageOffsets(arr => {
-                const _arr = [...arr]
-                _arr[id + 1] = newPageOffset
-                cacheSet(pageOffsetKey, _arr)
-                return _arr
-              })
-            }
-          }
-
           return _swrs
         })
+        if (typeof swr.data !== 'undefined') {
+          // set next page's offset
+          const newPageOffset = SWRToOffset(swr, id)
+          if (pageOffsets[id + 1] !== newPageOffset) {
+            setPageOffsets(arr => {
+              const _arr = [...arr]
+              _arr[id + 1] = newPageOffset
+              cacheSet(pageOffsetKey, _arr)
+              return _arr
+            })
+          }
+        }
       }
       return swr
     }

--- a/test/use-swr-pages.test.tsx
+++ b/test/use-swr-pages.test.tsx
@@ -34,7 +34,7 @@ describe('useSWRPages', () => {
           const { data } = withSWR(useSWR(String(offset || 0), v => v))
           return 'page ' + data + ', '
         },
-        (_, pageSWRs) => pageSWRs.length
+        (_, index) => index + 1
       )
 
       useEffect(() => {


### PR DESCRIPTION
After this change, the SWR -> offset function will pass the entire SWR object (so you can get the error / loading state as well), as well as the index of current page. (`pageSWRs` could be overkill and useless, and it causes some data inconsistency issues.)

### Before
```js
swrDataToOffset(data, pageSWRs)
```
e.g.:
```js
useSWRPages(
  ...,
  ...,
  (data, swrs) => offsetOfNextPage
)
```

### After
```js
SWRToOffset(SWR, index)
```
e.g.:
```js
useSWRPages(
  ...,
  ...,
  ({ data, error, ... }, indexOfCurrentPage) => offsetOfNextPage
)
```

Also added an example for it.
