### PR TITLE
Add null to types of keyInterface

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -37,7 +37,7 @@ export interface RevalidateOptionInterface {
 }
 
 type keyFunction = () => string
-export type keyInterface = string | keyFunction
+export type keyInterface = string | keyFunction | null
 export type updaterInterface<Data = any, Error = any> = (
   shouldRevalidate?: boolean,
   data?: Data,


### PR DESCRIPTION
Adds `null` to the `keyInterface` type since a key can be null (i.e. when returning from a function doing conditional fetching)

Fixes #94 