### PR TITLE
Args as key

### DIFF
--- a/src/libs/hash.ts
+++ b/src/libs/hash.ts
@@ -1,5 +1,5 @@
 // use WeakMap to store the object->key mapping
-// so the objects can be garbadge collected.
+// so the objects can be garbage collected.
 // WeakMap uses a hashtable under the hood, so the lookup
 // complexity is almost O(1).
 const table = new WeakMap()

--- a/src/libs/hash.ts
+++ b/src/libs/hash.ts
@@ -1,0 +1,28 @@
+// use WeakMap to store the object->key mapping
+// so the objects can be garbadge collected.
+// WeakMap uses a hashtable under the hood, so the lookup
+// complexity is almost O(1).
+const table = new WeakMap()
+
+// counter of the key
+let counter = 0
+
+// hashes an array of objects and returns a string
+export default function hash(args: any[]): string {
+  let key = 'arg'
+  for (let i = 0; i < args.length; ++i) {
+    let _hash
+    if (typeof args[i] !== 'object') {
+      _hash = String(args[i])
+    } else {
+      if (!table.has(args[i])) {
+        _hash = counter
+        table.set(args[i], counter++)
+      } else {
+        _hash = table.get(args[i])
+      }
+    }
+    key += '@' + _hash
+  }
+  return key
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -37,15 +37,18 @@ export interface RevalidateOptionInterface {
 }
 
 type keyFunction = () => string
-export type keyInterface = string | keyFunction | null
+export type keyInterface = string | keyFunction | any[] | null
 export type updaterInterface<Data = any, Error = any> = (
   shouldRevalidate?: boolean,
   data?: Data,
   error?: Error
 ) => boolean | Promise<boolean>
-export type triggerInterface = (key: string, shouldRevalidate?: boolean) => void
+export type triggerInterface = (
+  key: keyInterface,
+  shouldRevalidate?: boolean
+) => void
 export type mutateInterface<Data = any> = (
-  key: string,
+  key: keyInterface,
   data: Data,
   shouldRevalidate?: boolean
 ) => void

--- a/test/use-swr.test.tsx
+++ b/test/use-swr.test.tsx
@@ -189,7 +189,7 @@ describe('useSWR', () => {
     expect(container.textContent).toMatchInlineSnapshot(`"err err err"`)
   })
 
-  it.only('should accept object args', async () => {
+  it('should accept object args', async () => {
     const obj = { v: 'hello' }
     const arr = ['world']
 

--- a/test/use-swr.test.tsx
+++ b/test/use-swr.test.tsx
@@ -188,6 +188,39 @@ describe('useSWR', () => {
     await act(() => new Promise(res => setTimeout(res, 100)))
     expect(container.textContent).toMatchInlineSnapshot(`"err err err"`)
   })
+
+  it.only('should accept object args', async () => {
+    const obj = { v: 'hello' }
+    const arr = ['world']
+
+    function Page() {
+      const { data: v1 } = useSWR(
+        ['args-1', obj, arr],
+        (a, b, c) => a + b.v + c[0]
+      )
+
+      // reuse the cache
+      const { data: v2 } = useSWR(['args-1', obj, arr], () => 'not called!')
+
+      // different object
+      const { data: v3 } = useSWR(
+        ['args-2', obj, 'world'],
+        (a, b, c) => a + b.v + c
+      )
+
+      return (
+        <div>
+          {v1}, {v2}, {v3}
+        </div>
+      )
+    }
+    const { container } = render(<Page />)
+
+    await waitForDomChange({ container })
+    expect(container.textContent).toMatchInlineSnapshot(
+      `"args-1helloworld, args-1helloworld, args-2helloworld"`
+    )
+  })
 })
 
 describe('useSWR - refresh', () => {


### PR DESCRIPTION
This is a simple and efficient implementation of a frequently requested feature. 

Currently if you want to pass outside args to fetcher (which may change during the lifecycle):
```js
useSWR('key', () => fetcher(...args))
```
It doesn't work, because **the cache is indexed by the key**. Which means if your `args` change, a SWR refetch will not be triggered.

### Use Cases
GraphQL:
```js
const personQuery = `
  query Person(id: ID, name: String) {
    person(id: $id, name: $name) {
      id
    }
  }
`

// Reuse same query with different variables.
request(personQuery, { variables: { id: 42 } })
request(personQuery, { variables: { name: "Alice" } })
```

Multiple params:
```js
const token = useToken()

// SWR will still read the stale data even if `token` changes
const { data } = useSWR('/api/user', url => fetchAPI(url, token))
```

### New API

This implementation doesn't break any existing API or behavior, but allows you to use an array as the `key` param:

```js
useSWR([...args], fetcher, options)
```

And `arg` can be any value, object or even function. SWR will use those args as the key of the cache, and pass them as arguments to `fetcher`:

```js
fetcher(...args)
```

#### Notes
Same as React Hook deps, **don't** pass anonymous objects/arrays/functions, e.g.:
```js
const x = props.x

// this is wrong, because deps are compared shallowly (===)
useSWR(['hello', {value: x}], fetcher) 

// you can use useMemo
const v = useMemo(() => ({value: x}), [x])
useSWR(['hello', v], fetcher)

// or handle the logic inside fetcher
useSWR(['hello', x], (str, v) => fetcher(str, { value: v }))
```

Related: #37, #93.
Closes #40, closes #23.
