### PR TITLE
Fix visibilityState type

### DIFF
--- a/src/libs/is-document-visible.ts
+++ b/src/libs/is-document-visible.ts
@@ -3,10 +3,7 @@ export default function isDocumentVisible(): boolean {
     typeof document !== 'undefined' &&
     typeof document.visibilityState !== 'undefined'
   ) {
-    return (
-      document.visibilityState === 'visible' ||
-      document.visibilityState === 'prerender'
-    )
+    return document.visibilityState !== 'hidden'
   }
   // always assume it's visible
   return true


### PR DESCRIPTION
`prerender` is deprecated in Document.visibilityState, so it is undefined in `lib.dom.d.ts` 
> @see  https://developer.mozilla.org/en-US/docs/Web/API/Document/visibilityState

The editor will show error in `document.visibilityState === 'prerender'`

![20191108163125](https://user-images.githubusercontent.com/31642906/68462093-c9831a00-0246-11ea-904a-cda1a3c712e8.jpg)

<img width="648" alt="45D75031-25AC-4426-9411-E577C3D55332" src="https://user-images.githubusercontent.com/31642906/68462097-cab44700-0246-11ea-91e7-78a41c09b026.png">

So whe can  use `document.visibilityState !== 'hidden'` instead。It's compatible with the deprecated value and passable with editor checking~

