### PR TITLE
note on `key` parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,8 @@ const { data, error, isValidating, revalidate } = useSWR(key, fetcher, options)
 
 #### Parameters
 
-- `key`: a unique key string for the request (or a function / null) [(advanced usage)](#conditional-fetching)  
+- `key`: a unique key string for the request (or a function / null) [(advanced usage)](#conditional-fetching)
+   NOTE: `key` cannot be an object.  Suggest wrapping key in `JSON.stringify(key)` to accomodate.
 - `fetcher`: (_optional_) a Promise returning function to fetch your data [(details)](#data-fetching) 
 - `options`: (_optional_) an object of options for this SWR hook
 


### PR DESCRIPTION
I'm using this library with a services layer, so rather than a string, I pass in something like this for the key my fetcher needs:

```js
const key = { service: 'myFavoriteService', method: 'getProducts', payload: { 'keyword': 'pants' }}
const { data, error }  = useSWR(key, myServiceFetcher)
```

Found out I need to just `JSON.stringify` my `key` to get the caching behavior to work properly:
```js
const { data, error }  = useSWR(JSON.stringify(key), () => myServiceFetcher(key))
```