### PR TITLE
Add async mutation support

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,6 +326,18 @@ function Profile () {
 }
 ```
 
+In the example above, when clicking the button, it will send the request, **then** update the client data and 
+try to fetch the latest one (revalidate).
+
+But many POST APIs will just return the updated data directly, so we don’t need to revalidate again.  
+Here’s an example showing the “local mutate - request - update” usage:
+
+```js
+mutate('/api/user', newUser, false)      // use `false` to mutate without revalidation
+mutate('/api/user', updateUser(newUser)) // `updateUser` is a Promise of the request,
+                                         // which returns the updated document
+```
+
 ### Suspense Mode
 
 You can enable the `suspense` option to use SWR with React Suspense:
@@ -348,7 +360,8 @@ function App () {
 }
 ```
 
-Note in Suspense mode, `data` is always the fetch response (so you don't need to check if it's `undefined`). But if there's an error occurred, you need to use an [error boundary](https://reactjs.org/docs/concurrent-mode-suspense.html#handling-errors) to catch it.
+Note in Suspense mode, `data` is always the fetch response (so you don't need to check if it's `undefined`). 
+But if there's an error occurred, you need to use an [error boundary](https://reactjs.org/docs/concurrent-mode-suspense.html#handling-errors) to catch it.
 
 ### Error Retries
 

--- a/README.md
+++ b/README.md
@@ -338,7 +338,7 @@ function Profile () {
 }
 ```
 
-In the example above, when clicking the button, it will send the request, **then** update the client data and 
+Clicking the button in the example above will send a POST request to modify the remote data, locally update the client data and
 try to fetch the latest one (revalidate).
 
 But many POST APIs will just return the updated data directly, so we don’t need to revalidate again.  

--- a/src/types.ts
+++ b/src/types.ts
@@ -57,7 +57,7 @@ export type triggerInterface = (
 ) => void
 export type mutateInterface<Data = any> = (
   key: keyInterface,
-  data: Data,
+  data: Data | Promise<Data>,
   shouldRevalidate?: boolean
 ) => void
 export type broadcastStateInterface<Data = any, Error = any> = (

--- a/test/use-swr.test.tsx
+++ b/test/use-swr.test.tsx
@@ -602,6 +602,30 @@ describe('useSWR - local mutation', () => {
       `"data: truth"`
     )
   })
+
+  it('should support async mutation', async () => {
+    function Page() {
+      const { data } = useSWR('mutate-1', () => 0, {
+        dedupingInterval: 0
+      })
+      return <div>data: {data}</div>
+    }
+    const { container } = render(<Page />)
+
+    // hydration
+    expect(container.textContent).toMatchInlineSnapshot(`"data: "`)
+    await waitForDomChange({ container }) // mount
+    expect(container.textContent).toMatchInlineSnapshot(`"data: 0"`)
+    await act(() => {
+      // mutate and revalidate
+      return mutate(
+        'mutate-1',
+        new Promise(res => setTimeout(() => res(999), 100))
+      )
+    })
+    await act(() => new Promise(res => setTimeout(res, 110)))
+    expect(container.textContent).toMatchInlineSnapshot(`"data: 999"`)
+  })
 })
 
 describe('useSWR - context configs', () => {


### PR DESCRIPTION
With this change, the `data` parameter of `mutate` can be a promise, which returns the data or throws an error:

```js
mutate(key, Promise<Data>)
```

It can simplify scenarios like

```js
const newData = await update(...)   // some POST APIs return the updated data
mutate('/api/data', newData, false) // disable the revalidation here
```

to:

```js
mutate('/api/data', update(...)) // POST + mutate w/o revalidation
```

Related: #93.