### PR TITLE
Clarify about HTTP RFC 5861

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 
 SWR is a React Hooks library for remote data fetching.
 
-The name “**SWR**” is derived from `stale-while-revalidate`, a cache invalidation strategy popularized by [HTML RFC 5861](https://tools.ietf.org/html/rfc5861).  
+The name “**SWR**” is derived from `stale-while-revalidate`, a cache invalidation strategy popularized by [HTTP RFC 5861](https://tools.ietf.org/html/rfc5861).  
 **SWR** first returns the data from cache (stale), then sends the fetch request (revalidate), and finally comes with the up-to-date data again.
 
 It features:

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 
 SWR is a React Hooks library for remote data fetching.
 
-The name “**SWR**” is derived from `stale-while-revalidate`, a HTTP cache invalidation strategy popularized by [RFC 5861](https://tools.ietf.org/html/rfc5861).  
+The name “**SWR**” is derived from `stale-while-revalidate`, a cache invalidation strategy popularized by [HTML RFC 5861](https://tools.ietf.org/html/rfc5861).  
 **SWR** first returns the data from cache (stale), then sends the fetch request (revalidate), and finally comes with the up-to-date data again.
 
 It features:


### PR DESCRIPTION
Clarify that swr does not implement HTTP RFC 5861, but implements a cache invalidation strategy popularized by HTML RFC 5861, which may make reader confusing.