### PR TITLE
Check for window before using it

### DIFF
--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -353,6 +353,7 @@ function useSWR<Data = any, Error = any>(
     // trigger a revalidation
     if (
       typeof latestKeyedData !== 'undefined' &&
+      !IS_SERVER &&
       window['requestIdleCallback']
     ) {
       // delay revalidate if there's cache


### PR DESCRIPTION
We are using SWR in an environment without `window` variable, so need to check for the `window` variable.