### PR TITLE
Add react-native entry point to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "React Hooks library for remote data fetching",
   "main": "./dist/index.js",
   "module": "./esm/index.js",
+  "react-native": "./esm/index.js",
   "types": "./dist/index.d.ts",
   "files": [
     "dist/**",


### PR DESCRIPTION
fix #137 

- Add `react-native` to `package.json` to point to `esm` entry point
- Metro bundler will pick up the entry point per https://github.com/facebook/metro/blob/501add8cc1c2674ddb98302e47ff5194a80de3d7/packages/metro/src/ModuleGraph/node-haste/Package.js#L107-L130

**Test Steps**

- Clone `https://github.com/n3tr/ReactNativeSWRExample` (pointing to my custom build `swr` with `react-native` entry point inside `package.json`)
- `yarn install`
- `yarn start`
- Open new terminal window and run `yarn ios`
- App should build successfully
