### PR TITLE
Scripts on windows

### DIFF
--- a/examples/axios-typescript/libs/useRequest.ts
+++ b/examples/axios-typescript/libs/useRequest.ts
@@ -1,6 +1,5 @@
 import useSWR, { ConfigInterface, responseInterface } from 'swr'
 import axios, { AxiosRequestConfig, AxiosResponse, AxiosError } from 'axios'
-import { useMemo } from 'react'
 
 export type GetRequest = AxiosRequestConfig | null
 

--- a/package.json
+++ b/package.json
@@ -20,9 +20,9 @@
     "build:esm": "tsc --module ES6 --outDir esm",
     "watch": "tsc --watch",
     "types:check": "tsc --noEmit",
-    "format": "prettier --write '{src,test,examples}/**/*.{ts,tsx}'",
-    "lint": "eslint '{src,test,examples}/**/*.{ts,tsx}'",
-    "lint:fix": "eslint '{src,test,examples}/**/*.{ts,tsx}' --fix",
+    "format": "prettier --write \"{src,test,examples}/**/*.{ts,tsx}\"",
+    "lint": "eslint \"{src,test,examples}/**/*.{ts,tsx}\"",
+    "lint:fix": "eslint \"{src,test,examples}/**/*.{ts,tsx}\" --fix",
     "test": "jest"
   },
   "husky": {


### PR DESCRIPTION
This replaces the `'` in `package.json` scripts with `"` so that they can also run on Windows.

It also removes an unused import in an example I added in a previous PR.