### PR TITLE
Fix race condition

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -49,7 +49,8 @@ export type keyInterface = keyFunction | string | any[] | null
 export type updaterInterface<Data = any, Error = any> = (
   shouldRevalidate?: boolean,
   data?: Data,
-  error?: Error
+  error?: Error,
+  shouldDedupe?: boolean
 ) => boolean | Promise<boolean>
 export type triggerInterface = (
   key: keyInterface,

--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -77,7 +77,7 @@ const trigger: triggerInterface = (_key, shouldRevalidate = true) => {
     const currentData = cacheGet(key)
     const currentError = cacheGet(getErrorKey(key))
     for (let i = 0; i < updaters.length; ++i) {
-      updaters[i](shouldRevalidate, currentData, currentError)
+      updaters[i](shouldRevalidate, currentData, currentError, true)
     }
   }
 }
@@ -126,7 +126,7 @@ const mutate: mutateInterface = async (_key, _data, shouldRevalidate) => {
   const updaters = CACHE_REVALIDATORS[key]
   if (updaters) {
     for (let i = 0; i < updaters.length; ++i) {
-      updaters[i](!!shouldRevalidate, data, error)
+      updaters[i](!!shouldRevalidate, data, error, true)
     }
   }
 }
@@ -412,7 +412,8 @@ function useSWR<Data = any, Error = any>(
     const onUpdate: updaterInterface<Data, Error> = (
       shouldRevalidate = true,
       updatedData,
-      updatedError
+      updatedError,
+      dedupe = true
     ) => {
       // update hook state
       const newState: actionType<Data, Error> = {}
@@ -436,7 +437,11 @@ function useSWR<Data = any, Error = any>(
 
       keyRef.current = key
       if (shouldRevalidate) {
-        return softRevalidate()
+        if (dedupe) {
+          return softRevalidate()
+        } else {
+          return revalidate()
+        }
       }
       return false
     }


### PR DESCRIPTION
Make sure `mutate`, `revalidate` and `trigger` won't be ignored because of deduping and race conditions:
```
+------------------------------------------------------->A
ongoing request                                         stale response
       +-------------------------------------->B
       revalidate                             latest data
```

It should show **B** but the result is overridden by **A**, which is wrong. The sequence of responses should be ordered increasingly, by the start time of the corresponding requests.

Fix #153.