### PR TITLE
Allow newer minor versions of React as peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,6 @@
     "fast-deep-equal": "2.0.1"
   },
   "peerDependencies": {
-    "react": "16.11.0"
+    "react": "^16.11.0"
   }
 }


### PR DESCRIPTION
This PR opens up the peer dependency requirement to allow for newer minor releases of React without SWR starting to complain.