### PR TITLE
Fix config as second parameter in use-swr

### DIFF
--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -156,7 +156,7 @@ function useSWR<Data = any, Error = any>(
   if (args.length >= 1) {
     _key = args[0]
   }
-  if (args.length >= 2) {
+  if (args.length > 2) {
     fn = args[1]
     config = args[2]
   } else {

--- a/test/use-swr.test.tsx
+++ b/test/use-swr.test.tsx
@@ -260,6 +260,24 @@ describe('useSWR', () => {
       `"hello, SWR"`
     )
   })
+
+  it('should set config as second parameter', async () => {
+    const fetcher = jest.fn()
+
+    function Page() {
+      const { data } = useSWR('config-as-second-param', {
+        fetcher
+      })
+
+      return <div>hello, {data}</div>
+    }
+
+    const { container } = render(<Page />)
+
+    expect(container.firstChild.textContent).toMatchInlineSnapshot(`"hello, "`)
+
+    expect(fetcher).toBeCalled()
+  })
 })
 
 describe('useSWR - refresh', () => {

--- a/test/use-swr.test.tsx
+++ b/test/use-swr.test.tsx
@@ -262,7 +262,7 @@ describe('useSWR', () => {
   })
 
   it('should set config as second parameter', async () => {
-    const fetcher = jest.fn()
+    const fetcher = jest.fn(() => 'SWR')
 
     function Page() {
       const { data } = useSWR('config-as-second-param', {
@@ -275,8 +275,11 @@ describe('useSWR', () => {
     const { container } = render(<Page />)
 
     expect(container.firstChild.textContent).toMatchInlineSnapshot(`"hello, "`)
-
     expect(fetcher).toBeCalled()
+    await waitForDomChange({ container }) // mount
+    expect(container.firstChild.textContent).toMatchInlineSnapshot(
+      `"hello, SWR"`
+    )
   })
 })
 


### PR DESCRIPTION
If user wants to call `useSWR` hook with config object as second parameter, provided config object is interpreted as fetcher function and hook won't work.

This PR fixes that bug and adds test.

