### PR TITLE
set initialError to undefined if intialData is provided

### DIFF
--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -187,7 +187,7 @@ function useSWR<Data = any, Error = any>(
   }
 
   const initialData = cacheGet(key) || config.initialData
-  const initialError = cacheGet(keyErr)
+  const initialError = config.initialData ? undefined : cacheGet(keyErr)
 
   let [state, dispatch] = useReducer<reducerType<Data, Error>>(mergeState, {
     data: initialData,

--- a/test/use-swr.test.tsx
+++ b/test/use-swr.test.tsx
@@ -260,6 +260,27 @@ describe('useSWR', () => {
     )
   })
 
+  it('should ignore error cache when intial data provided', async () => {
+    function Page({ initialData = '' }) {
+      const { data, error } = useSWR(
+        'initial-data-2',
+        () => {
+          throw new Error('err')
+        },
+        {
+          initialData
+        }
+      )
+      if (error) return error.message
+      return <>{data}</>
+    }
+    const { container: containerErr, unmount } = render(<Page />)
+    expect(containerErr.textContent).toMatchInlineSnapshot(`"err"`)
+    unmount()
+    const { container } = render(<Page initialData="hello, Initial" />)
+    expect(container.textContent).toMatchInlineSnapshot(`"hello, Initial"`)
+  })
+
   it('should set config as second parameter', async () => {
     const fetcher = jest.fn(() => 'SWR')
 


### PR DESCRIPTION
This addresses #213 where passing initialData when there's an error in the cache will still return the error.

I'm not sure if this is the correct way to fix this as it means the cache and state would be out of sync but maybe that's ok? It did pass all tests 🤷‍♂ 
