### PR TITLE
Check if addEventListener and removeEventListener exists

### DIFF
--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -471,7 +471,7 @@ function useSWR<Data = any, Error = any>(
 
     // set up reconnecting when the browser regains network connection
     let reconnect = null
-    if (config.revalidateOnReconnect) {
+    if (addEventListener && config.revalidateOnReconnect) {
       reconnect = addEventListener('online', softRevalidate)
     }
 
@@ -501,7 +501,7 @@ function useSWR<Data = any, Error = any>(
         }
       }
 
-      if (reconnect !== null) {
+      if (removeEventListener && reconnect !== null) {
         removeEventListener('online', reconnect)
       }
     }


### PR DESCRIPTION
React Native app crashes after `swr` update because `revalidateOnReconnect` option is `true` by default and React Native has no `addEventListener ` and `removeEventListener ` in global scope.