### PR TITLE
Moving page cache to use a cache map

### DIFF
--- a/src/use-swr-pages.tsx
+++ b/src/use-swr-pages.tsx
@@ -177,7 +177,10 @@ export function useSWRPages<OffsetType = any, Data = any, Error = any>(
 
     // render each page
     const p = []
-    const pageCache = pageCacheMap.get(pageKey) || []
+    if (!pageCacheMap.has(pageKey)) {
+      pageCacheMap.set(pageKey, [])
+    }
+    const pageCache = pageCacheMap.get(pageKey)
     for (let i = 0; i < pageCount; ++i) {
       if (
         !pageCache[i] ||
@@ -197,7 +200,6 @@ export function useSWRPages<OffsetType = any, Data = any, Error = any>(
           pageFn: _pageFn,
           offset: pageOffsets[i]
         }
-        pageCacheMap.set(pageKey, pageCache)
       }
       p.push(pageCache[i].component)
     }

--- a/src/use-swr-pages.tsx
+++ b/src/use-swr-pages.tsx
@@ -88,6 +88,8 @@ function App () {
 }
 */
 
+const pageCacheMap = new Map()
+
 export function useSWRPages<OffsetType = any, Data = any, Error = any>(
   pageKey: string,
   pageFn: pageComponentType<OffsetType, Data, Error>,
@@ -105,7 +107,6 @@ export function useSWRPages<OffsetType = any, Data = any, Error = any>(
   )
   const [pageSWRs, setPageSWRs] = useState<responseInterface<Data, Error>[]>([])
 
-  const pageCacheRef = useRef([])
   const pageFnRef = useRef(pageFn)
   const emptyPageRef = useRef(false)
 
@@ -176,7 +177,7 @@ export function useSWRPages<OffsetType = any, Data = any, Error = any>(
 
     // render each page
     const p = []
-    const pageCache = pageCacheRef.current
+    const pageCache = pageCacheMap.get(pageKey) || []
     for (let i = 0; i < pageCount; ++i) {
       if (
         !pageCache[i] ||
@@ -196,6 +197,7 @@ export function useSWRPages<OffsetType = any, Data = any, Error = any>(
           pageFn: _pageFn,
           offset: pageOffsets[i]
         }
+        pageCacheMap.set(pageKey, pageCache)
       }
       p.push(pageCache[i].component)
     }


### PR DESCRIPTION
Currently, changing the pageKey doesn't reset the pages cache, and theres no other way to clear the pages cache.

Might solve #189