### PR TITLE
Fix check for addEventListener existence

### DIFF
--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -471,7 +471,7 @@ function useSWR<Data = any, Error = any>(
 
     // set up reconnecting when the browser regains network connection
     let reconnect = null
-    if (addEventListener && config.revalidateOnReconnect) {
+    if (typeof addEventListener !== 'undefined' && config.revalidateOnReconnect) {
       reconnect = addEventListener('online', softRevalidate)
     }
 

--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -501,7 +501,7 @@ function useSWR<Data = any, Error = any>(
         }
       }
 
-      if (removeEventListener && reconnect !== null) {
+      if (typeof removeEventListener !== 'undefined' && reconnect !== null) {
         removeEventListener('online', reconnect)
       }
     }


### PR DESCRIPTION
I noticed that React Native still crashes after applying the changes from #217.

More specifically the error I see is:

```
ReferenceError: Can't find variable: addEventListener
```

If you are seeing the same issue, this PR fixes that by checking if the variable `addEventListener` is defined as suggested here: https://stackoverflow.com/a/519157/2310187