### PR TITLE
revalidateOnMount flag that disable automatic revalidation on mount

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ const { data, error, isValidating, mutate } = useSWR(key, fetcher, options)
 - `suspense = false`: enable React Suspense mode [(details)](#suspense-mode)
 - `fetcher = undefined`: the default fetcher function
 - `initialData`: initial data to be returned (note: This is per-hook)
-- `revalidateInitialData = true`: automatically revalidate when component is mounted
+- `revalidateOnMount = true`: automatically revalidate when component is mounted
 - `revalidateOnFocus = true`: auto revalidate when window gets focused
 - `revalidateOnReconnect = true`: automatically revalidate when the browser regains a network connection (via `navigator.onLine`)
 - `refreshInterval = 0`: polling interval (disabled by default)
@@ -239,12 +239,12 @@ const { data } = useSWR(() => shouldFetch ? '/api/data' : null, fetcher)
 const { data } = useSWR(() => '/api/data?uid=' + user.id, fetcher)
 ```
 
-If you want to use a constant `key` and prevent initial revalidation you can simply set `revalidateInitialData` option to false.
+If you want to use a constant `key` and prevent initial revalidation you can simply set `revalidateOnMount` option to false.
 
 ```js
 // disable automatic revalidation on mount
 const { data } = useSWR('/api/data', fetcher, {
-  revalidateInitialData: false
+  revalidateOnMount: false
 })
 
 // ...later you can trigger revalidation in a callback or after another event

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ const { data, error, isValidating, mutate } = useSWR(key, fetcher, options)
 - `suspense = false`: enable React Suspense mode [(details)](#suspense-mode)
 - `fetcher = undefined`: the default fetcher function
 - `initialData`: initial data to be returned (note: This is per-hook)
-- `revalidateOnMount = true`: automatically revalidate when component is mounted
+- `revalidateOnMount`: enable or disable automatic revalidation when component is mounted (by default revalidation occurs on mount when initialData is not set, use this flag to force behavior)
 - `revalidateOnFocus = true`: auto revalidate when window gets focused
 - `revalidateOnReconnect = true`: automatically revalidate when the browser regains a network connection (via `navigator.onLine`)
 - `refreshInterval = 0`: polling interval (disabled by default)

--- a/README.md
+++ b/README.md
@@ -239,18 +239,6 @@ const { data } = useSWR(() => shouldFetch ? '/api/data' : null, fetcher)
 const { data } = useSWR(() => '/api/data?uid=' + user.id, fetcher)
 ```
 
-If you want to use a constant `key` and prevent initial revalidation you can simply set `revalidateOnMount` option to false.
-
-```js
-// disable automatic revalidation on mount
-const { data } = useSWR('/api/data', fetcher, {
-  revalidateOnMount: false
-})
-
-// ...later you can trigger revalidation in a callback or after another event
-const onClick = useCallback(() => trigger('/api/data'), [])
-```
-
 ### Dependent Fetching
 
 SWR also allows you to fetch data that depends on other data. It ensures the maximum possible parallelism (avoiding waterfalls), as well as serial fetching when a piece of dynamic data is required for the next data fetch to happen.

--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ const { data, error, isValidating, mutate } = useSWR(key, fetcher, options)
 - `suspense = false`: enable React Suspense mode [(details)](#suspense-mode)
 - `fetcher = undefined`: the default fetcher function
 - `initialData`: initial data to be returned (note: This is per-hook)
+- `revalidateInitialData = true`: automatically revalidate when component is mounted
 - `revalidateOnFocus = true`: auto revalidate when window gets focused
 - `revalidateOnReconnect = true`: automatically revalidate when the browser regains a network connection (via `navigator.onLine`)
 - `refreshInterval = 0`: polling interval (disabled by default)
@@ -236,6 +237,18 @@ const { data } = useSWR(() => shouldFetch ? '/api/data' : null, fetcher)
 
 // ... or throw an error when user.id is not defined
 const { data } = useSWR(() => '/api/data?uid=' + user.id, fetcher)
+```
+
+If you want to use a constant `key` and prevent initial revalidation you can simply set `revalidateInitialData` option to false.
+
+```js
+// disable automatic revalidation on mount
+const { data } = useSWR('/api/data', fetcher, {
+  revalidateInitialData: false
+})
+
+// ...later you can trigger revalidation in a callback or after another event
+const onClick = useCallback(() => trigger('/api/data'), [])
 ```
 
 ### Dependent Fetching

--- a/src/config.ts
+++ b/src/config.ts
@@ -64,7 +64,7 @@ const defaultConfig: ConfigInterface = {
   dedupingInterval: 2 * 1000,
   loadingTimeout: (slowConnection ? 5 : 3) * 1000,
 
-  revalidateInitialData: true,
+  revalidateOnMount: true,
   refreshInterval: 0,
   revalidateOnFocus: true,
   revalidateOnReconnect: true,

--- a/src/config.ts
+++ b/src/config.ts
@@ -64,7 +64,6 @@ const defaultConfig: ConfigInterface = {
   dedupingInterval: 2 * 1000,
   loadingTimeout: (slowConnection ? 5 : 3) * 1000,
 
-  revalidateOnMount: true,
   refreshInterval: 0,
   revalidateOnFocus: true,
   revalidateOnReconnect: true,

--- a/src/config.ts
+++ b/src/config.ts
@@ -64,7 +64,7 @@ const defaultConfig: ConfigInterface = {
   dedupingInterval: 2 * 1000,
   loadingTimeout: (slowConnection ? 5 : 3) * 1000,
 
-  autoLoad: true,
+  revalidateInitialData: true,
   refreshInterval: 0,
   revalidateOnFocus: true,
   revalidateOnReconnect: true,

--- a/src/config.ts
+++ b/src/config.ts
@@ -64,6 +64,7 @@ const defaultConfig: ConfigInterface = {
   dedupingInterval: 2 * 1000,
   loadingTimeout: (slowConnection ? 5 : 3) * 1000,
 
+  autoLoad: true,
   refreshInterval: 0,
   revalidateOnFocus: true,
   revalidateOnReconnect: true,

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,6 +4,7 @@ export interface ConfigInterface<
   Error = any,
   Fn extends fetcherFn<Data> = fetcherFn<Data>
 > {
+  autoLoad?: boolean;
   errorRetryInterval?: number
   errorRetryCount?: number
   loadingTimeout?: number

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,7 +4,7 @@ export interface ConfigInterface<
   Error = any,
   Fn extends fetcherFn<Data> = fetcherFn<Data>
 > {
-  autoLoad?: boolean;
+  revalidateInitialData?: boolean
   errorRetryInterval?: number
   errorRetryCount?: number
   loadingTimeout?: number

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,7 +4,6 @@ export interface ConfigInterface<
   Error = any,
   Fn extends fetcherFn<Data> = fetcherFn<Data>
 > {
-  revalidateOnMount?: boolean
   errorRetryInterval?: number
   errorRetryCount?: number
   loadingTimeout?: number
@@ -14,6 +13,7 @@ export interface ConfigInterface<
   refreshWhenHidden?: boolean
   refreshWhenOffline?: boolean
   revalidateOnFocus?: boolean
+  revalidateOnMount?: boolean
   revalidateOnReconnect?: boolean
   shouldRetryOnError?: boolean
   fetcher?: Fn

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,7 +4,7 @@ export interface ConfigInterface<
   Error = any,
   Fn extends fetcherFn<Data> = fetcherFn<Data>
 > {
-  revalidateInitialData?: boolean
+  revalidateOnMount?: boolean
   errorRetryInterval?: number
   errorRetryCount?: number
   loadingTimeout?: number

--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -356,7 +356,7 @@ function useSWR<Data = any, Error = any>(
 
   // mounted (client side rendering)
   useIsomorphicLayoutEffect(() => {
-    if (!key) return undefined
+    if (!key || !config.autoLoad) return undefined
 
     // after `key` updates, we need to mark it as mounted
     unmountedRef.current = false

--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -381,7 +381,7 @@ function useSWR<Data = any, Error = any>(
     const softRevalidate = () => revalidate({ dedupe: true })
 
     // trigger a revalidation
-    if (!config.initialData || config.revalidateInitialData) {
+    if (!config.initialData && config.revalidateOnMount) {
       if (
         typeof latestKeyedData !== 'undefined' &&
         !IS_SERVER &&

--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -381,7 +381,10 @@ function useSWR<Data = any, Error = any>(
     const softRevalidate = () => revalidate({ dedupe: true })
 
     // trigger a revalidation
-    if (!config.initialData && config.revalidateOnMount) {
+    if (
+      config.revalidateOnMount ||
+      (!config.initialData && config.revalidateOnMount === undefined)
+    ) {
       if (
         typeof latestKeyedData !== 'undefined' &&
         !IS_SERVER &&

--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -381,7 +381,7 @@ function useSWR<Data = any, Error = any>(
     const softRevalidate = () => revalidate({ dedupe: true })
 
     // trigger a revalidation
-    if (!config.initialData || !config.autoLoad) {
+    if (!config.initialData && config.autoLoad) {
       if (
         typeof latestKeyedData !== 'undefined' &&
         !IS_SERVER &&

--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -356,7 +356,7 @@ function useSWR<Data = any, Error = any>(
 
   // mounted (client side rendering)
   useIsomorphicLayoutEffect(() => {
-    if (!key || !config.autoLoad) return undefined
+    if (!key) return undefined
 
     // after `key` updates, we need to mark it as mounted
     unmountedRef.current = false
@@ -381,7 +381,7 @@ function useSWR<Data = any, Error = any>(
     const softRevalidate = () => revalidate({ dedupe: true })
 
     // trigger a revalidation
-    if (!config.initialData) {
+    if (!config.initialData || !config.autoLoad) {
       if (
         typeof latestKeyedData !== 'undefined' &&
         !IS_SERVER &&

--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -381,7 +381,7 @@ function useSWR<Data = any, Error = any>(
     const softRevalidate = () => revalidate({ dedupe: true })
 
     // trigger a revalidation
-    if (!config.initialData && config.revalidateInitialData) {
+    if (!config.initialData || config.revalidateInitialData) {
       if (
         typeof latestKeyedData !== 'undefined' &&
         !IS_SERVER &&

--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -381,7 +381,7 @@ function useSWR<Data = any, Error = any>(
     const softRevalidate = () => revalidate({ dedupe: true })
 
     // trigger a revalidation
-    if (!config.initialData && config.autoLoad) {
+    if (!config.initialData && config.revalidateInitialData) {
       if (
         typeof latestKeyedData !== 'undefined' &&
         !IS_SERVER &&

--- a/test/use-swr.test.tsx
+++ b/test/use-swr.test.tsx
@@ -85,7 +85,7 @@ describe('useSWR', () => {
     const fetch = jest.fn(() => 'SWR')
 
     function Page() {
-      const { data } = useSWR('constant-3', fetch)
+      const { data } = useSWR('auto-load', fetch, { autoLoad: false })
       return <div>hello, {data}</div>
     }
 

--- a/test/use-swr.test.tsx
+++ b/test/use-swr.test.tsx
@@ -95,6 +95,21 @@ describe('useSWR', () => {
     expect(fetch).not.toHaveBeenCalled()
   })
 
+  it('should call fetch function when revalidateOnMount is true even if initialData is set', async () => {
+    const fetch = jest.fn(() => 'SWR')
+
+    function Page() {
+      const { data } = useSWR('revalidateOnMount', fetch, {
+        revalidateOnMount: true,
+        initialData: 'gab'
+      })
+      return <div>hello, {data}</div>
+    }
+
+    render(<Page />)
+    expect(fetch).toHaveBeenCalled()
+  })
+
   it('should dedupe requests by default', async () => {
     let count = 0
     const fetch = () => {

--- a/test/use-swr.test.tsx
+++ b/test/use-swr.test.tsx
@@ -81,6 +81,18 @@ describe('useSWR', () => {
     )
   })
 
+  it('should not call fetch function when autoLoad is false', async () => {
+    const fetch = jest.fn(() => 'SWR')
+
+    function Page() {
+      const { data } = useSWR('constant-3', fetch)
+      return <div>hello, {data}</div>
+    }
+
+    render(<Page />)
+    expect(fetch).not.toHaveBeenCalled()
+  })
+
   it('should dedupe requests by default', async () => {
     let count = 0
     const fetch = () => {

--- a/test/use-swr.test.tsx
+++ b/test/use-swr.test.tsx
@@ -81,12 +81,12 @@ describe('useSWR', () => {
     )
   })
 
-  it('should not call fetch function when revalidateInitialData is false', async () => {
+  it('should not call fetch function when revalidateOnMount is false', async () => {
     const fetch = jest.fn(() => 'SWR')
 
     function Page() {
-      const { data } = useSWR('revalidateInitialData', fetch, {
-        revalidateInitialData: false
+      const { data } = useSWR('revalidateOnMount', fetch, {
+        revalidateOnMount: false
       })
       return <div>hello, {data}</div>
     }

--- a/test/use-swr.test.tsx
+++ b/test/use-swr.test.tsx
@@ -81,11 +81,13 @@ describe('useSWR', () => {
     )
   })
 
-  it('should not call fetch function when autoLoad is false', async () => {
+  it('should not call fetch function when revalidateInitialData is false', async () => {
     const fetch = jest.fn(() => 'SWR')
 
     function Page() {
-      const { data } = useSWR('auto-load', fetch, { autoLoad: false })
+      const { data } = useSWR('revalidateInitialData', fetch, {
+        revalidateInitialData: false
+      })
       return <div>hello, {data}</div>
     }
 


### PR DESCRIPTION
Hi there,
we're currently using useSWR but we have found conditional revalidation a bit limiting.

For example we have some occurences where we want to trigger revalidation only after a certain action is being taken (could be a button click).
With current conditional revalidation techniques we are forced to use an additional state just to prevent first validation on mount.

This PR aims to add a simple autoLoad (or whatever other name) flag in the options so that automatic revalidation on mount can be prevented and we can simply trigger it directly in a callback (for example a button onClick).

Best,
Gabriele