### PR TITLE
Expose Cache

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,3 @@
 dist/**/*
+esm/**/*
 node_modules

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -1,0 +1,29 @@
+import { CacheInterface } from './types'
+
+export default class Cache implements CacheInterface {
+  __cache: Map<string, any>
+
+  constructor(initialData: any = {}) {
+    this.__cache = new Map(Object.entries(initialData))
+  }
+
+  get(key: string): any {
+    return this.__cache.get(key)
+  }
+
+  set(key: string, value: any): any {
+    return this.__cache.set(key, value)
+  }
+
+  clear() {
+    this.__cache.clear()
+  }
+
+  delete(key: string) {
+    this.__cache.delete(key)
+  }
+
+  has(key: string) {
+    return this.__cache.has(key)
+  }
+}

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -8,15 +8,17 @@ export default class Cache implements CacheInterface {
 
   constructor(initialData: any = {}) {
     this.__cache = new Map(Object.entries(initialData))
-    this.__listeners = [];
+    this.__listeners = []
   }
 
-  get(key: string): any {
-    return this.__cache.get(key)
+  get(key: keyInterface): any {
+    const [_key] = this.serializeKey(key)
+    return this.__cache.get(_key)
   }
 
-  set(key: string, value: any, shouldNotify = true): any {
-    this.__cache.set(key, value)
+  set(key: keyInterface, value: any, shouldNotify = true): any {
+    const [_key] = this.serializeKey(key)
+    this.__cache.set(_key, value)
     if (shouldNotify) mutate(key, value, false)
     this.notify()
   }
@@ -25,8 +27,9 @@ export default class Cache implements CacheInterface {
     return Array.from(this.__cache.keys())
   }
 
-  has(key: string) {
-    return this.__cache.has(key)
+  has(key: keyInterface) {
+    const [_key] = this.serializeKey(key)
+    return this.__cache.has(_key)
   }
 
   clear(shouldNotify = true) {
@@ -35,9 +38,10 @@ export default class Cache implements CacheInterface {
     this.notify()
   }
 
-  delete(key: string, shouldNotify = true) {
+  delete(key: keyInterface, shouldNotify = true) {
+    const [_key] = this.serializeKey(key)
     if (shouldNotify) mutate(key, null, false)
-    this.__cache.delete(key)
+    this.__cache.delete(_key)
     this.notify()
   }
 
@@ -72,12 +76,12 @@ export default class Cache implements CacheInterface {
       throw new Error('Expected the listener to be a function.')
     }
 
-    let isSubscribed = true;
+    let isSubscribed = true
     this.__listeners.push(listener)
 
     return () => {
-      if (!isSubscribed) return;
-      isSubscribed = false;
+      if (!isSubscribed) return
+      isSubscribed = false
       const index = this.__listeners.indexOf(listener)
       if (index > -1) {
         this.__listeners[index] = this.__listeners[this.__listeners.length - 1]

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -1,5 +1,6 @@
-import { CacheInterface } from './types'
+import { CacheInterface, keyInterface } from './types'
 import { mutate } from './use-swr'
+import hash from './libs/hash'
 
 export default class Cache implements CacheInterface {
   __cache: Map<string, any>
@@ -29,5 +30,31 @@ export default class Cache implements CacheInterface {
   delete(key: string, shouldNotify = true) {
     if (shouldNotify) mutate(key, null, false)
     this.__cache.delete(key)
+  }
+
+  // TODO: introduce namespace for the cache
+  serializeKey(key: keyInterface): [string, any, string] {
+    let args = null
+    if (typeof key === 'function') {
+      try {
+        key = key()
+      } catch (err) {
+        // dependencies not ready
+        key = ''
+      }
+    }
+
+    if (Array.isArray(key)) {
+      // args array
+      args = key
+      key = hash(key)
+    } else {
+      // convert null to ''
+      key = String(key || '')
+    }
+
+    const errorKey = key ? 'err@' + key : ''
+
+    return [key, args, errorKey]
   }
 }

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -79,7 +79,10 @@ export default class Cache implements CacheInterface {
       if (!isSubscribed) return;
       isSubscribed = false;
       const index = this.__listeners.indexOf(listener)
-      this.__listeners.splice(index, 1)
+      if (index > -1) {
+        this.__listeners[index] = this.__listeners[this.__listeners.length - 1]
+        this.__listeners.length--
+      }
     }
   }
 

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -1,4 +1,5 @@
 import { CacheInterface } from './types'
+import { mutate } from './use-swr'
 
 export default class Cache implements CacheInterface {
   __cache: Map<string, any>
@@ -11,19 +12,22 @@ export default class Cache implements CacheInterface {
     return this.__cache.get(key)
   }
 
-  set(key: string, value: any): any {
-    return this.__cache.set(key, value)
-  }
-
-  clear() {
-    this.__cache.clear()
-  }
-
-  delete(key: string) {
-    this.__cache.delete(key)
+  set(key: string, value: any, shouldNotify = true): any {
+    this.__cache.set(key, value)
+    if (shouldNotify) mutate(key, value, false)
   }
 
   has(key: string) {
     return this.__cache.has(key)
+  }
+
+  clear(shouldNotify = true) {
+    if (shouldNotify) this.__cache.forEach(key => mutate(key, null, false))
+    this.__cache.clear()
+  }
+
+  delete(key: string, shouldNotify = true) {
+    if (shouldNotify) mutate(key, null, false)
+    this.__cache.delete(key)
   }
 }

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -3,7 +3,7 @@ import { mutate } from './use-swr'
 import hash from './libs/hash'
 
 export default class Cache implements CacheInterface {
-  __cache: Map<string, any>
+  private __cache: Map<string, any>
 
   constructor(initialData: any = {}) {
     this.__cache = new Map(Object.entries(initialData))

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,3 +1,4 @@
+import deepEqual from 'fast-deep-equal'
 import isDocumentVisible from './libs/is-document-visible'
 import isOnline from './libs/is-online'
 import {
@@ -76,7 +77,8 @@ const defaultConfig: ConfigInterface = {
   refreshWhenHidden: false,
   refreshWhenOffline: false,
   shouldRetryOnError: true,
-  suspense: false
+  suspense: false,
+  compare: deepEqual
 }
 
 // Focus revalidate

--- a/src/config.ts
+++ b/src/config.ts
@@ -49,6 +49,14 @@ function onErrorRetry(
   setTimeout(revalidate, timeout, opts)
 }
 
+// client side: need to adjust the config
+// based on the browser status
+// slow connection (<= 70Kbps)
+const slowConnection =
+  typeof window !== 'undefined' &&
+  navigator['connection'] &&
+  ['slow-2g', '2g'].indexOf(navigator['connection'].effectiveType) !== -1
+
 // config
 const defaultConfig: ConfigInterface = {
   // events
@@ -57,10 +65,10 @@ const defaultConfig: ConfigInterface = {
   onError: () => {},
   onErrorRetry,
 
-  errorRetryInterval: 5 * 1000,
+  errorRetryInterval: (slowConnection ? 10 : 5) * 1000,
   focusThrottleInterval: 5 * 1000,
   dedupingInterval: 2 * 1000,
-  loadingTimeout: 3 * 1000,
+  loadingTimeout: (slowConnection ? 5 : 3) * 1000,
 
   refreshInterval: 0,
   revalidateOnFocus: true,
@@ -69,21 +77,6 @@ const defaultConfig: ConfigInterface = {
   refreshWhenOffline: false,
   shouldRetryOnError: true,
   suspense: false
-}
-
-if (typeof window !== 'undefined') {
-  // client side: need to adjust the config
-  // based on the browser status
-
-  // slow connection (<= 70Kbps)
-  if (navigator['connection']) {
-    if (
-      ['slow-2g', '2g'].indexOf(navigator['connection'].effectiveType) !== -1
-    ) {
-      defaultConfig.errorRetryInterval = 10 * 1000
-      defaultConfig.loadingTimeout = 5 * 1000
-    }
-  }
 }
 
 // Focus revalidate

--- a/src/config.ts
+++ b/src/config.ts
@@ -67,8 +67,7 @@ const defaultConfig: ConfigInterface = {
   refreshWhenOffline: false,
   shouldRetryOnError: true,
   suspense: false,
-  compare: deepEqual,
-  cache
+  compare: deepEqual
 }
 
 // Focus revalidate

--- a/src/config.ts
+++ b/src/config.ts
@@ -6,21 +6,10 @@ import {
   RevalidateOptionInterface,
   revalidateType
 } from './types'
+import Cache from './cache'
 
-// Cache
-const __cache = new Map()
-
-function cacheGet(key: string): any {
-  return __cache.get(key)
-}
-
-function cacheSet(key: string, value: any) {
-  return __cache.set(key, value)
-}
-
-function cacheClear() {
-  __cache.clear()
-}
+// cache
+const cache = new Cache()
 
 // state managers
 const CONCURRENT_PROMISES = {}
@@ -78,7 +67,8 @@ const defaultConfig: ConfigInterface = {
   refreshWhenOffline: false,
   shouldRetryOnError: true,
   suspense: false,
-  compare: deepEqual
+  compare: deepEqual,
+  cache
 }
 
 // Focus revalidate
@@ -103,8 +93,6 @@ export {
   FOCUS_REVALIDATORS,
   CACHE_REVALIDATORS,
   MUTATION_TS,
-  cacheGet,
-  cacheSet,
-  cacheClear
+  cache
 }
 export default defaultConfig

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,4 +9,5 @@ export {
   responseInterface,
   CacheInterface
 } from './types'
+export { default as Cache } from './cache'
 export default useSWR

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 export * from './use-swr'
 import { default as useSWR } from './use-swr'
 export { useSWRPages } from './use-swr-pages'
+export { cache } from './config'
 export {
   ConfigInterface,
   revalidateType,

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ export {
   revalidateType,
   RevalidateOptionInterface,
   keyInterface,
-  responseInterface
+  responseInterface,
+  CacheInterface
 } from './types'
 export default useSWR

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,5 +10,4 @@ export {
   responseInterface,
   CacheInterface
 } from './types'
-export { default as Cache } from './cache'
 export default useSWR

--- a/src/types.ts
+++ b/src/types.ts
@@ -37,6 +37,8 @@ export interface ConfigInterface<
     revalidate: revalidateType,
     revalidateOpts: RevalidateOptionInterface
   ) => void
+
+  compare?: (a: Data | undefined, b: Data | undefined) => boolean
 }
 
 export interface RevalidateOptionInterface {

--- a/src/types.ts
+++ b/src/types.ts
@@ -117,4 +117,5 @@ export interface CacheInterface {
   has(key: string): boolean
   delete(key: string, shouldNotify?: boolean): void
   clear(shouldNotify?: boolean): void
+  serializeKey(key: keyInterface): [string, any, string]
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -117,14 +117,14 @@ export type actionType<Data, Error> = {
 }
 
 export interface CacheInterface {
-  get(key: string): any
-  set(key: string, value: any, shouldNotify?: boolean): any
+  get(key: keyInterface): any
+  set(key: keyInterface, value: any, shouldNotify?: boolean): any
   keys(): string[]
-  has(key: string): boolean
-  delete(key: string, shouldNotify?: boolean): void
+  has(key: keyInterface): boolean
+  delete(key: keyInterface, shouldNotify?: boolean): void
   clear(shouldNotify?: boolean): void
   serializeKey(key: keyInterface): [string, any, string]
   subscribe(listener: cacheListener): () => void
 }
 
-export type cacheListener = () => void;
+export type cacheListener = () => void

--- a/src/types.ts
+++ b/src/types.ts
@@ -39,6 +39,8 @@ export interface ConfigInterface<
   ) => void
 
   compare?: (a: Data | undefined, b: Data | undefined) => boolean
+
+  cache?: CacheInterface
 }
 
 export interface RevalidateOptionInterface {
@@ -109,4 +111,12 @@ export type actionType<Data, Error> = {
   data?: Data
   error?: Error
   isValidating?: boolean
+}
+
+export interface CacheInterface {
+  set(key: string, value: any): any
+  get(key: string): any
+  delete(key: string): void
+  has(key: string): boolean
+  clear(): void
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -119,8 +119,12 @@ export type actionType<Data, Error> = {
 export interface CacheInterface {
   get(key: string): any
   set(key: string, value: any, shouldNotify?: boolean): any
+  keys(): string[]
   has(key: string): boolean
   delete(key: string, shouldNotify?: boolean): void
   clear(shouldNotify?: boolean): void
   serializeKey(key: keyInterface): [string, any, string]
+  subscribe(listener: cacheListener): () => void
 }
+
+export type cacheListener = () => void;

--- a/src/types.ts
+++ b/src/types.ts
@@ -39,8 +39,6 @@ export interface ConfigInterface<
   ) => void
 
   compare?: (a: Data | undefined, b: Data | undefined) => boolean
-
-  cache?: CacheInterface
 }
 
 export interface RevalidateOptionInterface {
@@ -114,9 +112,9 @@ export type actionType<Data, Error> = {
 }
 
 export interface CacheInterface {
-  set(key: string, value: any): any
   get(key: string): any
-  delete(key: string): void
+  set(key: string, value: any, shouldNotify?: boolean): any
   has(key: string): boolean
-  clear(): void
+  delete(key: string, shouldNotify?: boolean): void
+  clear(shouldNotify?: boolean): void
 }

--- a/src/use-swr-pages.tsx
+++ b/src/use-swr-pages.tsx
@@ -88,6 +88,8 @@ function App () {
 }
 */
 
+const pageCacheMap = new Map()
+
 export function useSWRPages<OffsetType = any, Data = any, Error = any>(
   pageKey: string,
   pageFn: pageComponentType<OffsetType, Data, Error>,
@@ -105,7 +107,6 @@ export function useSWRPages<OffsetType = any, Data = any, Error = any>(
   )
   const [pageSWRs, setPageSWRs] = useState<responseInterface<Data, Error>[]>([])
 
-  const pageCacheRef = useRef([])
   const pageFnRef = useRef(pageFn)
   const emptyPageRef = useRef(false)
 
@@ -176,7 +177,10 @@ export function useSWRPages<OffsetType = any, Data = any, Error = any>(
 
     // render each page
     const p = []
-    const pageCache = pageCacheRef.current
+    if (!pageCacheMap.has(pageKey)) {
+      pageCacheMap.set(pageKey, [])
+    }
+    const pageCache = pageCacheMap.get(pageKey)
     for (let i = 0; i < pageCount; ++i) {
       if (
         !pageCache[i] ||

--- a/src/use-swr-pages.tsx
+++ b/src/use-swr-pages.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useMemo, useState, useRef } from 'react'
 
-import { cacheGet, cacheSet } from './config'
+import { cache } from './config'
 import {
   pagesResponseInterface,
   responseInterface,
@@ -100,10 +100,10 @@ export function useSWRPages<OffsetType = any, Data = any, Error = any>(
   const pageOffsetKey = `_swr_page_offset_` + pageKey
 
   const [pageCount, setPageCount] = useState<number>(
-    cacheGet(pageCountKey) || 1
+    cache.get(pageCountKey) || 1
   )
   const [pageOffsets, setPageOffsets] = useState<OffsetType[]>(
-    cacheGet(pageOffsetKey) || [null]
+    cache.get(pageOffsetKey) || [null]
   )
   const [pageSWRs, setPageSWRs] = useState<responseInterface<Data, Error>[]>([])
 
@@ -134,7 +134,7 @@ export function useSWRPages<OffsetType = any, Data = any, Error = any>(
   const loadMore = useCallback(() => {
     if (isLoadingMore || isReachingEnd) return
     setPageCount(c => {
-      cacheSet(pageCountKey, c + 1)
+      cache.set(pageCountKey, c + 1)
       return c + 1
     })
   }, [isLoadingMore || isReachingEnd])
@@ -166,7 +166,7 @@ export function useSWRPages<OffsetType = any, Data = any, Error = any>(
             setPageOffsets(arr => {
               const _arr = [...arr]
               _arr[id + 1] = newPageOffset
-              cacheSet(pageOffsetKey, _arr)
+              cache.set(pageOffsetKey, _arr)
               return _arr
             })
           }

--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -1,4 +1,3 @@
-import deepEqual from 'fast-deep-equal'
 import {
   useCallback,
   useContext,
@@ -309,7 +308,7 @@ function useSWR<Data = any, Error = any>(
           // we don't have an error
           newState.error = undefined
         }
-        if (deepEqual(stateRef.current.data, newData)) {
+        if (config.compare(stateRef.current.data, newData)) {
           // deep compare to avoid extra re-render
           // do nothing
         } else {
@@ -384,7 +383,7 @@ function useSWR<Data = any, Error = any>(
     // update the state if the key changed or cache updated
     if (
       keyRef.current !== key ||
-      !deepEqual(currentHookData, latestKeyedData)
+      !config.compare(currentHookData, latestKeyedData)
     ) {
       dispatch({ data: latestKeyedData })
       keyRef.current = key
@@ -434,7 +433,7 @@ function useSWR<Data = any, Error = any>(
 
       if (
         typeof updatedData !== 'undefined' &&
-        !deepEqual(stateRef.current.data, updatedData)
+        !config.compare(stateRef.current.data, updatedData)
       ) {
         newState.data = updatedData
         needUpdate = true

--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -471,7 +471,7 @@ function useSWR<Data = any, Error = any>(
 
     // set up reconnecting when the browser regains network connection
     let reconnect = null
-    if (addEventListener && config.revalidateOnReconnect) {
+    if (typeof addEventListener !== 'undefined' && config.revalidateOnReconnect) {
       reconnect = addEventListener('online', softRevalidate)
     }
 
@@ -501,7 +501,7 @@ function useSWR<Data = any, Error = any>(
         }
       }
 
-      if (removeEventListener && reconnect !== null) {
+      if (typeof removeEventListener !== 'undefined' && reconnect !== null) {
         removeEventListener('online', reconnect)
       }
     }

--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -67,7 +67,7 @@ const broadcastState: broadcastStateInterface = (key, data, error) => {
   }
 }
 
-const mutate: mutateInterface = async (_key, _data, shouldRevalidate) => {
+const mutate: mutateInterface = async (_key, _data, shouldRevalidate = true) => {
   const [key] = cache.serializeKey(_key)
   if (!key) return
 

--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -67,7 +67,11 @@ const broadcastState: broadcastStateInterface = (key, data, error) => {
   }
 }
 
-const mutate: mutateInterface = async (_key, _data, shouldRevalidate = true) => {
+const mutate: mutateInterface = async (
+  _key,
+  _data,
+  shouldRevalidate = true
+) => {
   const [key] = cache.serializeKey(_key)
   if (!key) return
 

--- a/test/use-swr.test.tsx
+++ b/test/use-swr.test.tsx
@@ -305,7 +305,7 @@ describe('useSWR', () => {
       </div>
     `)
 
-    // content should come from fetcher due lack of cached data
+    // content should be updated with fetcher results
     expect(await findByText('random message')).toMatchInlineSnapshot(`
       <div>
         random message

--- a/test/use-swr.test.tsx
+++ b/test/use-swr.test.tsx
@@ -7,7 +7,8 @@ import {
 } from '@testing-library/react'
 import React, { ReactNode, Suspense, useEffect, useState } from 'react'
 
-import useSWR, { mutate, SWRConfig, trigger, cache, Cache } from '../src'
+import useSWR, { mutate, SWRConfig, trigger, cache } from '../src'
+import Cache from '../src/cache'
 
 class ErrorBoundary extends React.Component<{ fallback: ReactNode }> {
   state = { hasError: false }

--- a/test/use-swr.test.tsx
+++ b/test/use-swr.test.tsx
@@ -7,7 +7,7 @@ import {
 } from '@testing-library/react'
 import React, { ReactNode, Suspense, useEffect, useState } from 'react'
 
-import useSWR, { mutate, SWRConfig, trigger, cache } from '../src'
+import useSWR, { mutate, SWRConfig, trigger, cache, Cache } from '../src'
 
 class ErrorBoundary extends React.Component<{ fallback: ReactNode }> {
   state = { hasError: false }
@@ -279,56 +279,6 @@ describe('useSWR', () => {
     expect(container.firstChild.textContent).toMatchInlineSnapshot(
       `"hello, SWR"`
     )
-  })
-
-  it('should react to direct cache updates', async () => {
-    cache.set('custom-cache-key', 'custom cache message')
-
-    function Page() {
-      const { data } = useSWR('custom-cache-key', () => 'random message', {
-        suspense: true
-      })
-      return <div>{data}</div>
-    }
-
-    // render using custom cache
-    const { queryByText, findByText } = render(
-      <React.Suspense fallback={null}>
-        <Page />
-      </React.Suspense>
-    )
-
-    // content should come from custom cache
-    expect(queryByText('custom cache message')).toMatchInlineSnapshot(`
-      <div>
-        custom cache message
-      </div>
-    `)
-
-    // content should be updated with fetcher results
-    expect(await findByText('random message')).toMatchInlineSnapshot(`
-      <div>
-        random message
-      </div>
-    `)
-
-    act(() => cache.set('custom-cache-key', 'a different message'))
-
-    // content should be updated from new cache value
-    expect(await findByText('a different message')).toMatchInlineSnapshot(`
-      <div>
-        a different message
-      </div>
-    `)
-
-    act(() => cache.delete('custom-cache-key'))
-
-    // content should go back to be the fetched value
-    expect(await findByText('random message')).toMatchInlineSnapshot(`
-      <div>
-        random message
-      </div>
-    `)
   })
 })
 
@@ -1299,4 +1249,73 @@ describe('useSWR - suspense', () => {
     // 'suspense-7' -> undefined -> 'suspense-8'
     expect(renderedResults).toEqual(['suspense-7', 'suspense-8'])
   })
+})
+
+describe.only('useSWR - cache', () => {
+  it('should react to direct cache updates', async () => {
+    cache.set('cache-1', 'custom cache message')
+
+    function Page() {
+      const { data } = useSWR('cache-1', () => 'random message', {
+        suspense: true
+      })
+      return <div>{data}</div>
+    }
+
+    // render using custom cache
+    const { queryByText, findByText } = render(
+      <React.Suspense fallback={null}>
+        <Page />
+      </React.Suspense>
+    )
+
+    // content should come from custom cache
+    expect(queryByText('custom cache message')).toMatchInlineSnapshot(`
+      <div>
+        custom cache message
+      </div>
+    `)
+
+    // content should be updated with fetcher results
+    expect(await findByText('random message')).toMatchInlineSnapshot(`
+      <div>
+        random message
+      </div>
+    `)
+
+    act(() => cache.set('cache-1', 'a different message'))
+
+    // content should be updated from new cache value
+    expect(await findByText('a different message')).toMatchInlineSnapshot(`
+      <div>
+        a different message
+      </div>
+    `)
+
+    act(() => cache.delete('cache-1'))
+
+    // content should go back to be the fetched value
+    expect(await findByText('random message')).toMatchInlineSnapshot(`
+      <div>
+        random message
+      </div>
+    `)
+  })
+
+  it('should notify subscribers when a cache item changed', async () => {
+    // create new cache instance to don't get affected by other tests
+    // updating the normal cache instance
+    const tmpCache = new Cache()
+
+    const listener = jest.fn()
+    const unsubscribe = tmpCache.subscribe(listener);
+    tmpCache.set("cache-2", "random message");
+
+    expect(listener).toHaveBeenCalled()
+
+    unsubscribe();
+    tmpCache.set("cache-2", "a different message");
+
+    expect(listener).toHaveBeenCalled()
+  });
 })

--- a/test/use-swr.test.tsx
+++ b/test/use-swr.test.tsx
@@ -1251,7 +1251,7 @@ describe('useSWR - suspense', () => {
   })
 })
 
-describe.only('useSWR - cache', () => {
+describe('useSWR - cache', () => {
   it('should react to direct cache updates', async () => {
     cache.set('cache-1', 'custom cache message')
 
@@ -1308,14 +1308,14 @@ describe.only('useSWR - cache', () => {
     const tmpCache = new Cache()
 
     const listener = jest.fn()
-    const unsubscribe = tmpCache.subscribe(listener);
-    tmpCache.set("cache-2", "random message");
+    const unsubscribe = tmpCache.subscribe(listener)
+    tmpCache.set('cache-2', 'random message')
 
     expect(listener).toHaveBeenCalled()
 
-    unsubscribe();
-    tmpCache.set("cache-2", "a different message");
+    unsubscribe()
+    tmpCache.set('cache-2', 'a different message')
 
     expect(listener).toHaveBeenCalledTimes(1)
-  });
+  })
 })

--- a/test/use-swr.test.tsx
+++ b/test/use-swr.test.tsx
@@ -7,7 +7,7 @@ import {
 } from '@testing-library/react'
 import React, { ReactNode, Suspense, useEffect, useState } from 'react'
 
-import useSWR, { mutate, SWRConfig, trigger } from '../src'
+import useSWR, { mutate, SWRConfig, trigger, Cache } from '../src'
 
 class ErrorBoundary extends React.Component<{ fallback: ReactNode }> {
   state = { hasError: false }
@@ -355,6 +355,47 @@ describe('useSWR - loading', () => {
     // it doesn't re-render, but fetch was triggered
     expect(renderCount).toEqual(1)
     expect(dataLoaded).toEqual(true)
+  })
+
+  it('should use custom cache', async () => {
+    const cache = new Cache({
+      'custom-cache-1': 'custom cache message'
+    })
+
+    function Page() {
+      const { data } = useSWR('custom-cache-1', () => 'random message', {
+        suspense: true
+      })
+      return <div>{data}</div>
+    }
+
+    // render using custom cache
+    const { queryByText, findByText, rerender } = render(
+      <SWRConfig value={{ cache }}>
+        <Page />
+      </SWRConfig>
+    )
+
+    // content should come from custom cache
+    expect(queryByText('custom cache message')).toMatchInlineSnapshot(`
+      <div>
+        custom cache message
+      </div>
+    `)
+
+    // render againt with default cache
+    rerender(
+      <React.Suspense fallback={null}>
+        <Page />
+      </React.Suspense>
+    )
+
+    // content should come from fetcher due lack of cached data
+    expect(await findByText('random message')).toMatchInlineSnapshot(`
+      <div>
+        random message
+      </div>
+    `)
   })
 })
 

--- a/test/use-swr.test.tsx
+++ b/test/use-swr.test.tsx
@@ -1316,6 +1316,6 @@ describe.only('useSWR - cache', () => {
     unsubscribe();
     tmpCache.set("cache-2", "a different message");
 
-    expect(listener).toHaveBeenCalled()
+    expect(listener).toHaveBeenCalledTimes(1)
   });
 })


### PR DESCRIPTION
This attempts to partially resolve #212 and resolves #161 and resolves #237 and resolves #158

## Implementation Notes

I updated this to only expose the global cache, I kept the cache interface, adding a way to tell the `set`, `delete` and `clear` methods if you want to notify components reading from the cache, this way `mutate` can call `cache.set` and `cache.set` can also call `mutate` as a notification method without running on a infinite loop (mutate calls `cache.set` with this flag as `false`).

I did this to come back to custom cache once I found a way to let `mutate` know which cache to call without manually passing it.

~I created a CacheInterface and make the global config create a default instance of the cache, also exported both the interface and the Cache class.~

~I also updated `useSWR` to read from the cache instance received through the context object.~

~I was not able, yet, to find a way to make `mutate` and `trigger` read from the correct cache instance, because they are global my only idea so far was to pass the cache instance as a third argument (probably optional), but that could make it hard to test components using a custom cache for tests and a default cache for the mutate call.~

## Missing things
~- `useSWRPages` is still using global cache (I haven't tried yet to use it here but I believe is the same as `mutate` and `trigger`)~
~- `mutate` is still using global cache~
~- `trigger` is still using global cache~

Any feedback is welcomed!