### PR TITLE
Fix a race condition bug

### DIFF
--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -275,12 +275,12 @@ function useSWR<Data = any, Error = any>(
 
           CONCURRENT_PROMISES_TS[key] = startAt = Date.now()
 
+          newData = await CONCURRENT_PROMISES[key]
+
           setTimeout(() => {
             delete CONCURRENT_PROMISES[key]
             delete CONCURRENT_PROMISES_TS[key]
           }, config.dedupingInterval)
-
-          newData = await CONCURRENT_PROMISES[key]
 
           // trigger the success event,
           // only do this for the original request.
@@ -470,7 +470,10 @@ function useSWR<Data = any, Error = any>(
 
     // set up reconnecting when the browser regains network connection
     let reconnect = null
-    if (typeof addEventListener !== 'undefined' && config.revalidateOnReconnect) {
+    if (
+      typeof addEventListener !== 'undefined' &&
+      config.revalidateOnReconnect
+    ) {
       reconnect = addEventListener('online', softRevalidate)
     }
 


### PR DESCRIPTION
`await CONCURRENT_PROMISES[key]` should be called *before* deduping. Because there could be this potential bug, say `dedupingInterval` is 2s:

```
0s: A ... GET /api
2s: delete CONCURRENT_PROMISES[key]
3s: B ... GET /api
4s: B -> response
5s: A -> response
```

Which is a race condition, the request fired first got returned last.

(Also added a test for `mutate` in this PR)