### PR TITLE
Export the existing cacheClear function (one liner)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -9,3 +9,5 @@ export {
   responseInterface
 } from './types'
 export default useSWR
+
+export { cacheClear } from './config'

--- a/test/use-swr.test.tsx
+++ b/test/use-swr.test.tsx
@@ -1086,7 +1086,7 @@ describe('useSWR - suspense', () => {
 describe('useSWR - cacheClear', () => {
   afterEach(cleanup)
 
-  it('uses cached date when cacheClear() is not called', async () => {
+  it('uses cached data when cacheClear() is not called', async () => {
     function Page() {
       const { data } = useSWR('constant-6', () => 'SWR', {
         dedupingInterval: 0
@@ -1108,7 +1108,7 @@ describe('useSWR - cacheClear', () => {
     )
   })
 
-  it('re-fetches when cacheClear() is called', async () => {
+  it('does not use the cache when cacheClear() is called', async () => {
     function Page() {
       const { data } = useSWR('constant-7', () => 'SWR', {
         dedupingInterval: 0


### PR DESCRIPTION
I think this fixes https://github.com/zeit/swr/issues/161 by simply exposing an existing `cacheClear` function.

I've seen other PRs that address other cache related issues, but I think this is the minimum set of changes (one line) that will enable isolated deterministic tests when manipulating the "key" is not an option.