### PR TITLE
Fix polling conditions

### DIFF
--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -537,7 +537,7 @@ function useSWR<Data = any, Error = any>(
       if (
         !stateRef.current.error &&
         (config.refreshWhenHidden || isDocumentVisible()) &&
-        (!config.refreshWhenOffline && isOnline())
+        (config.refreshWhenOffline || isOnline())
       ) {
         // only revalidate when the page is visible
         // if API request errored, we stop polling in this round


### PR DESCRIPTION
Should only continue polling if `refreshWhenOffline` is set to true (allowed to poll offline), or it's online.

Close #247. Thanks @madmanwithabike for reporting!