### PR TITLE
Add mutateMany function

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -58,14 +58,14 @@ export type triggerInterface = (
   key: keyInterface,
   shouldRevalidate?: boolean
 ) => void
-type mutateCallback<Data = any> = (currentValue: Data) => Data
+type mutateCallback<Data = any> = (currentValue: Data, key: string) => Data
 export type mutateInterface<Data = any> = (
   key: keyInterface,
   data?: Data | Promise<Data> | mutateCallback<Data>,
   shouldRevalidate?: boolean
 ) => Promise<Data | undefined>
 export type mutateManyInterface<Data = any> = (
-  select: (key: keyInterface) => boolean,
+  select: (key: string) => boolean,
   data?: Data | Promise<Data> | mutateCallback<Data>,
   shouldRevalidate?:
     | boolean

--- a/src/types.ts
+++ b/src/types.ts
@@ -64,6 +64,13 @@ export type mutateInterface<Data = any> = (
   data?: Data | Promise<Data> | mutateCallback<Data>,
   shouldRevalidate?: boolean
 ) => Promise<Data | undefined>
+export type mutateManyInterface<Data = any> = (
+  select: (key: keyInterface) => boolean,
+  data?: Data | Promise<Data> | mutateCallback<Data>,
+  shouldRevalidate?:
+    | boolean
+    | ((key: keyInterface, currentValue: Data) => boolean)
+) => Promise<Data[]>
 export type broadcastStateInterface<Data = any, Error = any> = (
   key: string,
   data: Data,


### PR DESCRIPTION
Resolves #264 

This PR adds a `mutateMany` function, it has the following definition

```ts
export type mutateManyInterface<Data = any> = (
  select: (key: keyInterface) => boolean,
  data?: Data | Promise<Data> | mutateCallback<Data>,
  shouldRevalidate?:
    | boolean
    | ((key: keyInterface, currentValue: Data) => boolean)
) => Promise<Data[]>
```

The function will be called as

```ts
mutateMany(
  key => key.startsWith("/api/users"),
  undefined
)
```

The way this function works is:

1. It calls select passing for each key in the cache, there you could check if you want to mutate it or not (returned true/false)
2. It calls `mutate` against the selected keys and pass data, this data is the same as `mutate`
3. It calls shouldRevalidate (if it's a function) passing the selected key to get if it should or not revalidate, it could also be a boolean to pass true/false to all selected keys

@quietshu if you think this is a good addition to SWR I could document it and add some tests.
