### PR TITLE
Add `Data` and `Error` generics to `pagesResponseInterface`

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -100,10 +100,10 @@ export type pageOffsetMapperType<Offset, Data, Error> = (
   index: number
 ) => Offset
 
-export type pagesResponseInterface = {
+export type pagesResponseInterface<Data, Error> = {
   pages: any
   pageCount: number
-  pageSWRs: responseInterface<any, any>[]
+  pageSWRs: responseInterface<Data, Error>[]
   isLoadingMore: boolean
   isReachingEnd: boolean
   isEmpty: boolean

--- a/src/use-swr-pages.tsx
+++ b/src/use-swr-pages.tsx
@@ -95,7 +95,7 @@ export function useSWRPages<OffsetType = any, Data = any, Error = any>(
   pageFn: pageComponentType<OffsetType, Data, Error>,
   SWRToOffset: pageOffsetMapperType<OffsetType, Data, Error>,
   deps: any[] = []
-): pagesResponseInterface {
+): pagesResponseInterface<Data, Error> {
   const pageCountKey = `_swr_page_count_` + pageKey
   const pageOffsetKey = `_swr_page_offset_` + pageKey
 


### PR DESCRIPTION
I noticed `pageSWRs` in the `pagesResponseInterface` type was typed with `<any, any>`. I fixed this with the `Data` and `Error` generics.