### PR TITLE
Dedupe duplicate requests after mutation

### DIFF
--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -40,8 +40,6 @@ const IS_SERVER = typeof window === 'undefined'
 // useLayoutEffect in the browser.
 const useIsomorphicLayoutEffect = IS_SERVER ? useEffect : useLayoutEffect
 
-const NO_DEDUPE = false
-
 const trigger: triggerInterface = (_key, shouldRevalidate = true) => {
   // we are ignoring the second argument which correspond to the arguments
   // the fetcher will receive when key is an array
@@ -53,7 +51,7 @@ const trigger: triggerInterface = (_key, shouldRevalidate = true) => {
     const currentData = cache.get(key)
     const currentError = cache.get(keyErr)
     for (let i = 0; i < updaters.length; ++i) {
-      updaters[i](shouldRevalidate, currentData, currentError, NO_DEDUPE)
+      updaters[i](shouldRevalidate, currentData, currentError, i > 0)
     }
   }
 }
@@ -110,7 +108,7 @@ const mutate: mutateInterface = async (
   const updaters = CACHE_REVALIDATORS[key]
   if (updaters) {
     for (let i = 0; i < updaters.length; ++i) {
-      updaters[i](!!shouldRevalidate, data, error, NO_DEDUPE)
+      updaters[i](!!shouldRevalidate, data, error, i > 0)
     }
   }
 

--- a/test/use-swr.test.tsx
+++ b/test/use-swr.test.tsx
@@ -806,7 +806,7 @@ describe('useSWR - local mutation', () => {
     expect(container.firstChild.textContent).toMatchInlineSnapshot(`"data: 1"`)
   })
 
-  it('should trigger revalidation programmatically with a dedupingInterval', async () => {
+  it('should trigger revalidation programmatically within a dedupingInterval', async () => {
     let value = 0
 
     function Page() {
@@ -852,11 +852,14 @@ describe('useSWR - local mutation', () => {
     expect(container.firstChild.textContent).toMatchInlineSnapshot(`"data: 1"`)
   })
 
-  it('should mutate the cache and revalidate with a dedupingInterval', async () => {
+  it('should dedupe extra requests after mutation', async () => {
     let value = 0
 
     function Page() {
       const { data } = useSWR('dynamic-13', () => value++, {
+        dedupingInterval: 2000
+      })
+      useSWR('dynamic-13', () => value++, {
         dedupingInterval: 2000
       })
       return <div>data: {data}</div>
@@ -869,7 +872,7 @@ describe('useSWR - local mutation', () => {
     expect(container.firstChild.textContent).toMatchInlineSnapshot(`"data: 0"`)
     await act(() => {
       // mutate and revalidate
-      mutate('dynamic-13', 'mutate')
+      mutate('dynamic-13')
       return new Promise(res => setTimeout(res, 1))
     })
     expect(container.firstChild.textContent).toMatchInlineSnapshot(`"data: 1"`)


### PR DESCRIPTION
Fix #295.

Additionally, test case `dynamic-13` seems to be the same with `dynamic-12` so I just changed it.