### PR TITLE
Fix 'reconnect' assignment

### DIFF
--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -468,7 +468,7 @@ function useSWR<Data = any, Error = any>(
       typeof addEventListener !== 'undefined' &&
       config.revalidateOnReconnect
     ) {
-      reconnect = addEventListener('online', softRevalidate)
+      addEventListener('online', (reconnect = softRevalidate))
     }
 
     return () => {


### PR DESCRIPTION
```js
reconnect = addEventListener('online', softRevalidate)
```
`addEventListener()` return `undefined`，should change to:
```js
addEventListener('online', reconnect = softRevalidate)
```