### PR TITLE
Update examples/server-render: Use getServerSideProps

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,12 +389,12 @@ try {
 ### SSR with Next.js
 
 With the `initialData` option, you pass an initial value to the hook. It works perfectly with many SSR solutions
-such as `getInitialProps` in [Next.js](https://github.com/zeit/next.js):
+such as `getServerSideProps` in [Next.js](https://github.com/zeit/next.js):
 
 ```js
-App.getInitialProps = async () => {
+export async function getServerSideProps() {
   const data = await fetcher('/api/data')
-  return { data }
+  return { props: { data } }
 }
 
 function App (props) {

--- a/examples/server-render/README.md
+++ b/examples/server-render/README.md
@@ -33,6 +33,6 @@ now
 
 ## The Idea behind the Example
 
-This examples show how to combine Next.js getInitialProps with the SWR `initialData` option to support Server-Side Rendering.
+This examples show how to combine Next.js getServerSideProps with the SWR `initialData` option to support Server-Side Rendering.
 
 The application will fetch the data server-side and then receive it as props, that data will be passed as `initialData` to SWR, once the application starts client-side SWR will revalidate it against the API and update the DOM, if it's required, with the new data.

--- a/examples/server-render/package.json
+++ b/examples/server-render/package.json
@@ -6,8 +6,8 @@
   "dependencies": {
     "isomorphic-unfetch": "3.0.0",
     "next": "9.3.1",
-    "react": "16.11.0",
-    "react-dom": "16.11.0",
+    "react": "16.13.0",
+    "react-dom": "16.13.0",
     "swr": "latest"
   },
   "scripts": {

--- a/examples/server-render/package.json
+++ b/examples/server-render/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "dependencies": {
     "isomorphic-unfetch": "3.0.0",
-    "next": "9.1.1",
+    "next": "9.3.1",
     "react": "16.11.0",
     "react-dom": "16.11.0",
     "swr": "latest"

--- a/examples/server-render/pages/[pokemon].js
+++ b/examples/server-render/pages/[pokemon].js
@@ -36,7 +36,7 @@ export default function Pokemon({ pokemon, initialData }) {
   )
 }
 
-Pokemon.getInitialProps = async ({ query }) => {
+export async function getServerSideProps({ query }) {
   const data = await fetcher(getURL(query.pokemon))
-  return { initialData: data, pokemon: query.pokemon }
+  return { props: { initialData: data, pokemon: query.pokemon } }
 }

--- a/examples/server-render/pages/index.js
+++ b/examples/server-render/pages/index.js
@@ -26,7 +26,7 @@ export default function Home({ initialData }) {
   )
 }
 
-Home.getInitialProps = async () => {
+export async function getServerSideProps() {
   const data = await fetcher(URL)
-  return { initialData: data }
+  return { props: { initialData: data } }
 }


### PR DESCRIPTION
Next.js 9.3 introduced a new API `getServerSideProps`.

https://nextjs.org/blog/next-9-3#next-gen-static-site-generation-ssg-support