### PR TITLE
use latest swr in examples/local-state-sharing

### DIFF
--- a/examples/local-state-sharing/package.json
+++ b/examples/local-state-sharing/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "dependencies": {
     "next": "9.3.3",
-    "swr": "link:../.."
+    "swr": "latest"
   },
   "scripts": {
     "dev": "next",


### PR DESCRIPTION
```
[ error ] ./pages/index.js 
Module not found: Can't resolve 'swr' in '/Users/s07840/swr/examples/local-state-sharing/pages'
```