### PR TITLE
fix: data inconsist on key change when fetcher is synchronized

### DIFF
--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -597,7 +597,7 @@ function useSWR<Data = any, Error = any>(
       data: {
         get: function() {
           stateDependencies.current.data = true
-          return keyRef.current === key ? stateRef.current.data : initialError
+          return keyRef.current === key ? stateRef.current.data : initialData
         }
       },
       isValidating: {

--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -591,13 +591,13 @@ function useSWR<Data = any, Error = any>(
         // so we need to match the latest key and data (fallback to `initialData`)
         get: function() {
           stateDependencies.current.error = true
-          return stateRef.current.error
+          return keyRef.current === key ? stateRef.current.error : initialError
         }
       },
       data: {
         get: function() {
           stateDependencies.current.data = true
-          return stateRef.current.data
+          return keyRef.current === key ? stateRef.current.data : initialError
         }
       },
       isValidating: {


### PR DESCRIPTION
## What

bugfix for #361 
I feel the issue was introduced in e6cca41846241e3c29b98cb4b8eba0e7ccc94 

## Why

`revalidate` gets excuted when react clearing effects, which is after the key changed.
see the example provided in #361 , when the key and data are both updated to the next state (since fetcher is synchornized and finished immediantely), swr still use the data of last key instead of retriving from cache with new key.

#### Phase
1. user triggers setState -> key change -> data change (sync)
2. swr detects key change
3. swr returns memoized state with last data **(not expected)**
4. swr `revalidate`
5. swr returns correct value
