### PR TITLE
Remove the server side suspense warning

### DIFF
--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -528,9 +528,6 @@ function useSWR<Data = any, Error = any>(
 
   // suspense
   if (config.suspense) {
-    if (IS_SERVER)
-      throw new Error('Suspense on server side is not yet supported!')
-
     // in suspense mode, we can't return empty state
     // (it should be suspended)
 


### PR DESCRIPTION
In concurrent mode Suspense is supported in server side, we can remove this warning.