### PR TITLE
Fix return type of mutateCallback

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -58,7 +58,7 @@ export type triggerInterface = (
   key: keyInterface,
   shouldRevalidate?: boolean
 ) => void
-type mutateCallback<Data = any> = (currentValue: Data) => Data
+type mutateCallback<Data = any> = (currentValue: Data) => Promise<Data>
 export type mutateInterface<Data = any> = (
   key: keyInterface,
   data?: Data | Promise<Data> | mutateCallback<Data>,


### PR DESCRIPTION
When using `mutate` with a function ([as per the README example](https://github.com/zeit/swr#mutate-based-on-current-data)), I had a TS error coming from an invalid type.
That's because the callback is an async function returning a promise which needs to be resolved ([and is in the code](https://github.com/zeit/swr/blob/48e199e3ccf3addeee1bf3e25aad4711647dd355/src/use-swr.ts#L87)). I fixed the type in this PR.

Code:
```ts
mutate('/api/users', async (users) => {
  const user = await fetcher('/api/users/1')
  return [user, ...users.slice(1)]
})
```

TS error:
```
Type 'Promise<User[]>' is missing the following properties from type 'User[]': length, pop, push, concat, and 26 more.
Did you mean to call this expression?
```