### PR TITLE
Change mutateCallback type to allow non-promise return value

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -59,7 +59,7 @@ export type triggerInterface = (
   key: keyInterface,
   shouldRevalidate?: boolean
 ) => void
-type mutateCallback<Data = any> = (currentValue: Data) => Promise<Data>
+type mutateCallback<Data = any> = (currentValue: Data) => Promise<Data> | Data
 export type mutateInterface<Data = any> = (
   key: keyInterface,
   data?: Data | Promise<Data> | mutateCallback<Data>,


### PR DESCRIPTION
I use swr mutate in a typescript project in combination with a [curried produce](https://immerjs.github.io/immer/docs/curried-produce) from immer, which returns a function that accepts the current data and returns the new data. With version 0.2.1, my build breaks because of a changed type in mutateCallback. This is only a typescript error - the code continues to work.

In #381, the return type for mutateCallback was changed to a promise. In order to also support this curried produce from immer, it should also accept the non promise value.

You can see the error in action here: https://codesandbox.io/s/elated-gould-j4pfc