### PR TITLE
Updated asset link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![SWR](https://assets.zeit.co/image/upload/v1572289618/swr/banner.png)](https://swr.now.sh)
+[![SWR](https://assets.vercel.com/image/upload/v1572289618/swr/banner.png)](https://swr.now.sh)
 
 <p align="center">
 


### PR DESCRIPTION
Replaced the outdated `assets.zeit.co` hostname with `assets.vercel.com`.