### PR TITLE
Fix No bound mutate returned by useRequest hook.

### DIFF
--- a/examples/axios-typescript/libs/useRequest.ts
+++ b/examples/axios-typescript/libs/useRequest.ts
@@ -6,7 +6,7 @@ export type GetRequest = AxiosRequestConfig | null
 interface Return<Data, Error>
   extends Pick<
     responseInterface<AxiosResponse<Data>, AxiosError<Error>>,
-    'isValidating' | 'revalidate' | 'error'
+    'isValidating' | 'revalidate' | 'error' | 'mutate'
   > {
   data: Data | undefined
   response: AxiosResponse<Data> | undefined
@@ -24,7 +24,7 @@ export default function useRequest<Data = unknown, Error = unknown>(
   request: GetRequest,
   { initialData, ...config }: Config<Data, Error> = {}
 ): Return<Data, Error> {
-  const { data: response, error, isValidating, revalidate } = useSWR<
+  const { data: response, error, isValidating, revalidate, mutate } = useSWR<
     AxiosResponse<Data>,
     AxiosError<Error>
   >(
@@ -52,6 +52,7 @@ export default function useRequest<Data = unknown, Error = unknown>(
     response,
     error,
     isValidating,
-    revalidate
+    revalidate,
+    mutate
   }
 }


### PR DESCRIPTION
useRequest hook does not return bound mutate function which is returned by useSwr hook.
so it becomes impossible to use bound mutate. This pr fixes that issue by returning mutate.